### PR TITLE
[FM-23] Add a new transaction

### DIFF
--- a/fm-backend/src/main/java/com/controller/TransactionController.java
+++ b/fm-backend/src/main/java/com/controller/TransactionController.java
@@ -1,15 +1,15 @@
 package com.controller;
 
-import com.dto.FileUpload;
 import com.dto.Transaction;
 import com.dto.request.NewTransactionRequest;
-import com.dto.response.FileInfoResponse;
+import com.dto.response.TransactionResponse;
 import com.service.TransactionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -17,6 +17,8 @@ import java.util.List;
 @RestController
 @RequestMapping("/transactions")
 public class TransactionController {
+
+    private static final Logger log = LoggerFactory.getLogger(TransactionController.class);
 
     @Autowired
     private TransactionService transactionService;
@@ -27,11 +29,14 @@ public class TransactionController {
     }
 
     @PostMapping("/transaction")
-    public ResponseEntity<HttpStatus> addTransaction(@RequestBody NewTransactionRequest request) {
-        Transaction transaction = new Transaction(
-                request.date(), request.account(), request.amount(), request.category(), request.paid_to(), request.memo());
-        transactionService.addTransaction(transaction);
-        return new ResponseEntity<>(HttpStatus.CREATED);
+    public ResponseEntity<?> addTransaction(@RequestBody NewTransactionRequest request) {
+        try {
+            TransactionResponse response = transactionService.addManualTransaction(request);
+            return new ResponseEntity<>(response, HttpStatus.CREATED);
+        } catch (IllegalArgumentException e) {
+            log.warn("Rejected new transaction request: {}", e.getMessage());
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
     }
 
     @DeleteMapping("/transaction/{id}")

--- a/fm-backend/src/main/java/com/dto/Transaction.java
+++ b/fm-backend/src/main/java/com/dto/Transaction.java
@@ -34,13 +34,28 @@ public class Transaction {
     private String memo;
     private String segment = "Undefined";
 
+    // FM-23: nullable so manually-added transactions (no CSV upload behind them) can persist with
+    // fileUpload = null. CSV-imported transactions are unaffected - CSVHelper always assigns a
+    // FileUpload before save, that behavior is unchanged; this only relaxes the DB constraint.
     @ManyToOne
-    @JoinColumn(name = "file_upload_id", referencedColumnName = "id", nullable = false)
+    @JoinColumn(name = "file_upload_id", referencedColumnName = "id", nullable = true)
     @JsonIgnore
     private FileUpload fileUpload;
 
     public Transaction(String date, BankAccount account, BigDecimal amount, String category, String paid_to, String memo) {
         this.date = transformStringToDate(date);
+        this.account = account;
+        this.amount = amount;
+        this.category = category;
+        this.paid_to = paid_to;
+        this.memo = memo;
+    }
+
+    // FM-23: used by the manual "add transaction" path, which already has a real LocalDate
+    // (parsed by Jackson's jsr310 module from ISO yyyy-MM-dd) and must not go through
+    // transformStringToDate - that parser expects d/M/yyyy (CSV format) and would throw on ISO input.
+    public Transaction(LocalDate date, BankAccount account, BigDecimal amount, String category, String paid_to, String memo) {
+        this.date = date;
         this.account = account;
         this.amount = amount;
         this.category = category;

--- a/fm-backend/src/main/java/com/dto/request/NewTransactionRequest.java
+++ b/fm-backend/src/main/java/com/dto/request/NewTransactionRequest.java
@@ -1,12 +1,16 @@
 package com.dto.request;
 
-import com.dto.BankAccount;
-
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
+// FM-23: date is a LocalDate (not String) so Jackson's jsr310 module parses the ISO yyyy-MM-dd
+// produced by a native <input type="date"> directly - the old String + Transaction.transformStringToDate
+// (d/M/yyyy split on "/") could not handle that format.
+// accountId is a real id looked up server-side via AccountRepository - the old shape accepted a
+// full client-supplied BankAccount object and persisted it as-is, which is not safe/correct.
 public record NewTransactionRequest(
-        String date,
-        BankAccount account,
+        LocalDate date,
+        int accountId,
         BigDecimal amount,
         String category,
         String paid_to,

--- a/fm-backend/src/main/java/com/dto/request/NewTransactionRequest.java
+++ b/fm-backend/src/main/java/com/dto/request/NewTransactionRequest.java
@@ -3,15 +3,6 @@ package com.dto.request;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
-// FM-23: date is a LocalDate (not String) so Jackson's jsr310 module parses the ISO yyyy-MM-dd
-// produced by a native <input type="date"> directly - the old String + Transaction.transformStringToDate
-// (d/M/yyyy split on "/") could not handle that format.
-// accountId is a real id looked up server-side via AccountRepository - the old shape accepted a
-// full client-supplied BankAccount object and persisted it as-is, which is not safe/correct.
-// accountId is boxed (Integer, not int) so a missing "accountId" key in the JSON payload
-// deserializes to null rather than silently defaulting to 0 - this lets the service distinguish
-// "accountId missing" from "accountId doesn't match any account" instead of relying on the
-// coincidence that generated ids start at 1.
 public record NewTransactionRequest(
         LocalDate date,
         Integer accountId,

--- a/fm-backend/src/main/java/com/dto/request/NewTransactionRequest.java
+++ b/fm-backend/src/main/java/com/dto/request/NewTransactionRequest.java
@@ -8,9 +8,13 @@ import java.time.LocalDate;
 // (d/M/yyyy split on "/") could not handle that format.
 // accountId is a real id looked up server-side via AccountRepository - the old shape accepted a
 // full client-supplied BankAccount object and persisted it as-is, which is not safe/correct.
+// accountId is boxed (Integer, not int) so a missing "accountId" key in the JSON payload
+// deserializes to null rather than silently defaulting to 0 - this lets the service distinguish
+// "accountId missing" from "accountId doesn't match any account" instead of relying on the
+// coincidence that generated ids start at 1.
 public record NewTransactionRequest(
         LocalDate date,
-        int accountId,
+        Integer accountId,
         BigDecimal amount,
         String category,
         String paid_to,

--- a/fm-backend/src/main/java/com/dto/response/AccountSummary.java
+++ b/fm-backend/src/main/java/com/dto/response/AccountSummary.java
@@ -1,0 +1,7 @@
+package com.dto.response;
+
+// FM-23: minimal id + name view of a BankAccount for embedding in TransactionResponse - the
+// success view only needs enough to display which account the transaction was saved against,
+// not the full BankAccount entity.
+public record AccountSummary(int id, String name) {
+}

--- a/fm-backend/src/main/java/com/dto/response/TransactionResponse.java
+++ b/fm-backend/src/main/java/com/dto/response/TransactionResponse.java
@@ -19,6 +19,9 @@ public record TransactionResponse(
 ) {
 
     public static TransactionResponse from(Transaction transaction) {
+        // transaction.getAccount() is assumed non-null here: every caller (TransactionService)
+        // validates the account exists before constructing/saving the Transaction, so this is
+        // safe today but relies on that invariant holding at every call site.
         AccountSummary account = new AccountSummary(
                 transaction.getAccount().getId(), transaction.getAccount().getName());
         return new TransactionResponse(

--- a/fm-backend/src/main/java/com/dto/response/TransactionResponse.java
+++ b/fm-backend/src/main/java/com/dto/response/TransactionResponse.java
@@ -1,0 +1,34 @@
+package com.dto.response;
+
+import com.dto.Transaction;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+// FM-23: response body for POST /transactions/transaction. Represents the persisted transaction
+// (backend is the source of truth for the save, including the generated id) rather than just
+// echoing back the client's submitted form values.
+public record TransactionResponse(
+        int id,
+        LocalDate date,
+        AccountSummary account,
+        BigDecimal amount,
+        String category,
+        String paid_to,
+        String memo
+) {
+
+    public static TransactionResponse from(Transaction transaction) {
+        AccountSummary account = new AccountSummary(
+                transaction.getAccount().getId(), transaction.getAccount().getName());
+        return new TransactionResponse(
+                transaction.getId(),
+                transaction.getDate(),
+                account,
+                transaction.getAmount(),
+                transaction.getCategory(),
+                transaction.getPaid_to(),
+                transaction.getMemo()
+        );
+    }
+}

--- a/fm-backend/src/main/java/com/service/TransactionService.java
+++ b/fm-backend/src/main/java/com/service/TransactionService.java
@@ -1,16 +1,16 @@
 package com.service;
 
-import com.dto.FileUpload;
+import com.dto.BankAccount;
 import com.dto.Transaction;
-import com.dto.response.FileInfoResponse;
-import com.helper.CSVHelper;
-import com.repository.FileUploadRepository;
+import com.dto.request.NewTransactionRequest;
+import com.dto.response.TransactionResponse;
+import com.repository.AccountRepository;
 import com.repository.TransactionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -18,12 +18,45 @@ public class TransactionService {
     @Autowired
     private TransactionRepository transactionRepository;
 
+    @Autowired
+    private AccountRepository accountRepository;
+
     public List<Transaction> getAllTransactions() {
         return transactionRepository.findAll();
     }
 
     public void addTransaction(Transaction transaction) {
         transactionRepository.save(transaction);
+    }
+
+    // FM-23: manual "add transaction" entry point. Validation lives here (not the controller)
+    // per CLAUDE.md layering - the frontend also validates, but there is no auth, so anything
+    // hitting this endpoint directly must still be checked server-side.
+    public TransactionResponse addManualTransaction(NewTransactionRequest request) {
+        if (request.amount() == null) {
+            throw new IllegalArgumentException("Amount is required");
+        }
+        if (request.amount().compareTo(BigDecimal.ZERO) == 0) {
+            throw new IllegalArgumentException("Amount cannot be zero");
+        }
+        if (request.paid_to() == null || request.paid_to().isBlank()) {
+            throw new IllegalArgumentException("Paid to is required");
+        }
+        if (request.date() == null) {
+            throw new IllegalArgumentException("Date is required");
+        }
+        if (request.date().isAfter(LocalDate.now())) {
+            throw new IllegalArgumentException("Date cannot be in the future");
+        }
+
+        BankAccount account = accountRepository.findById(request.accountId())
+                .orElseThrow(() -> new IllegalArgumentException("Account does not exist"));
+
+        // fileUpload intentionally left null - this transaction was not created via CSV import.
+        Transaction transaction = new Transaction(
+                request.date(), account, request.amount(), request.category(), request.paid_to(), request.memo());
+        Transaction saved = transactionRepository.save(transaction);
+        return TransactionResponse.from(saved);
     }
 
     public void deleteTransaction(int id){

--- a/fm-backend/src/main/java/com/service/TransactionService.java
+++ b/fm-backend/src/main/java/com/service/TransactionService.java
@@ -25,10 +25,6 @@ public class TransactionService {
         return transactionRepository.findAll();
     }
 
-    public void addTransaction(Transaction transaction) {
-        transactionRepository.save(transaction);
-    }
-
     // FM-23: manual "add transaction" entry point. Validation lives here (not the controller)
     // per CLAUDE.md layering - the frontend also validates, but there is no auth, so anything
     // hitting this endpoint directly must still be checked server-side.
@@ -49,6 +45,9 @@ public class TransactionService {
             throw new IllegalArgumentException("Date cannot be in the future");
         }
 
+        if (request.accountId() == null) {
+            throw new IllegalArgumentException("Account is required");
+        }
         BankAccount account = accountRepository.findById(request.accountId())
                 .orElseThrow(() -> new IllegalArgumentException("Account does not exist"));
 

--- a/fm-backend/src/test/java/com/controller/TransactionControllerTest.java
+++ b/fm-backend/src/test/java/com/controller/TransactionControllerTest.java
@@ -1,0 +1,139 @@
+package com.controller;
+
+import com.dto.request.NewTransactionRequest;
+import com.dto.response.AccountSummary;
+import com.dto.response.TransactionResponse;
+import com.service.TransactionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// FM-23: the QA-identified gap - every other test for this endpoint (TransactionServiceTest)
+// calls TransactionService.addManualTransaction(...) directly with hand-built Java objects,
+// never exercising real Jackson (de)serialization or the actual HTTP response shape. This test
+// posts real JSON through MockMvc and asserts the real 201/400 HTTP response, which is the only
+// place a regression in the date-serialization fix (LocalDate + jsr310 vs the old CSV-only
+// String/"d/M/yyyy" parser - the ticket's original defect, §2.3/§11 of the AC) would actually
+// surface: a unit test calling the service with an already-constructed LocalDate can never catch
+// a broken ISO-string-to-LocalDate deserialization path, only a real HTTP round trip can.
+@WebMvcTest(TransactionController.class)
+class TransactionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TransactionService transactionService;
+
+    private static final String VALID_JSON = """
+            {
+                "date": "2024-01-15",
+                "accountId": 1,
+                "amount": -25.50,
+                "category": "Groceries",
+                "paid_to": "Tesco",
+                "memo": "Weekly shop"
+            }
+            """;
+
+    // AC §8 backend #3 - fully valid payload -> 201, response body contains persisted transaction
+    // including generated id. Also proves the ISO date "2024-01-15" round-trips correctly end to
+    // end (both into the service as a real LocalDate, and back out in the JSON body) via real
+    // Jackson (de)serialization, not a hand-built Java object.
+    @Test
+    void validPayloadReturns201WithPersistedTransactionBody() throws Exception {
+        TransactionResponse stubbedResponse = new TransactionResponse(
+                42,
+                LocalDate.of(2024, 1, 15),
+                new AccountSummary(1, "Current Account"),
+                BigDecimal.valueOf(-25.50),
+                "Groceries",
+                "Tesco",
+                "Weekly shop"
+        );
+        when(transactionService.addManualTransaction(any(NewTransactionRequest.class)))
+                .thenReturn(stubbedResponse);
+
+        mockMvc.perform(post("/transactions/transaction")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(42))
+                .andExpect(jsonPath("$.date").value("2024-01-15"))
+                .andExpect(jsonPath("$.account.id").value(1))
+                .andExpect(jsonPath("$.account.name").value("Current Account"))
+                .andExpect(jsonPath("$.amount").value(-25.50))
+                .andExpect(jsonPath("$.category").value("Groceries"))
+                .andExpect(jsonPath("$.paid_to").value("Tesco"))
+                .andExpect(jsonPath("$.memo").value("Weekly shop"));
+
+        // Confirms the ISO date string in the JSON body was actually deserialized into a real
+        // LocalDate (not left as a String, and not thrown away) before reaching the service -
+        // this is the specific defect this test exists to guard against.
+        org.mockito.ArgumentCaptor<NewTransactionRequest> captor =
+                org.mockito.ArgumentCaptor.forClass(NewTransactionRequest.class);
+        verify(transactionService).addManualTransaction(captor.capture());
+        org.junit.jupiter.api.Assertions.assertEquals(LocalDate.of(2024, 1, 15), captor.getValue().date());
+        org.junit.jupiter.api.Assertions.assertEquals(1, captor.getValue().accountId());
+    }
+
+    // AC §8 backend #4/#5/#6/#7 - the service rejects the request (any of the validated cases) ->
+    // controller must translate IllegalArgumentException into a real 400 HTTP response with the
+    // exception's message as a plain-text body, matching the existing UploadController pattern.
+    @Test
+    void serviceRejectionReturns400WithMessageBody() throws Exception {
+        when(transactionService.addManualTransaction(any(NewTransactionRequest.class)))
+                .thenThrow(new IllegalArgumentException("Amount cannot be zero"));
+
+        mockMvc.perform(post("/transactions/transaction")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(VALID_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Amount cannot be zero"));
+    }
+
+    // AC §2.3/§8 backend #4 - a JSON payload that omits the "accountId" key entirely must
+    // deserialize accountId as null (not a default int like 0), reach the service, and result in
+    // the service's explicit "Account is required" 400 rather than an int-unboxing NPE/500 - only
+    // observable via a real deserialization pass, not a hand-built NewTransactionRequest.
+    @Test
+    void payloadMissingAccountIdKeyDeserializesAsNullAndReturns400() throws Exception {
+        String jsonMissingAccountId = """
+                {
+                    "date": "2024-01-15",
+                    "amount": -25.50,
+                    "category": "Groceries",
+                    "paid_to": "Tesco",
+                    "memo": "Weekly shop"
+                }
+                """;
+        when(transactionService.addManualTransaction(any(NewTransactionRequest.class)))
+                .thenThrow(new IllegalArgumentException("Account is required"));
+
+        mockMvc.perform(post("/transactions/transaction")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonMissingAccountId))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Account is required"));
+
+        org.mockito.ArgumentCaptor<NewTransactionRequest> captor =
+                org.mockito.ArgumentCaptor.forClass(NewTransactionRequest.class);
+        verify(transactionService).addManualTransaction(captor.capture());
+        org.junit.jupiter.api.Assertions.assertNull(captor.getValue().accountId());
+    }
+}

--- a/fm-backend/src/test/java/com/repository/TransactionPersistenceTest.java
+++ b/fm-backend/src/test/java/com/repository/TransactionPersistenceTest.java
@@ -1,0 +1,69 @@
+package com.repository;
+
+import com.dto.BankAccount;
+import com.dto.FileUpload;
+import com.dto.Transaction;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+// FM-23 §1/§8 (backend items 1-2): confirms the DDL change (Transaction.fileUpload's
+// @JoinColumn now nullable = true) actually behaves as intended at the DB level -
+// manual transactions can persist with a null FK, and a transaction created the CSV-import
+// way still correctly links a non-null FileUpload.
+@DataJpaTest
+class TransactionPersistenceTest {
+
+    @Autowired
+    private TransactionRepository transactionRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private FileUploadRepository fileUploadRepository;
+
+    @Test
+    void manuallyAddedTransactionPersistsWithNullFileUpload() {
+        BankAccount account = accountRepository.save(
+                new BankAccount("Current Account", "SORTCODE", "ACCNUMBER", new BigDecimal(2000), LocalDate.now()));
+
+        Transaction transaction = new Transaction(
+                LocalDate.now(), account, BigDecimal.valueOf(-25.50), "Groceries", "Tesco", "Weekly shop");
+        // fileUpload deliberately left unset (null) - this is the manual-entry path.
+
+        Transaction saved = transactionRepository.saveAndFlush(transaction);
+
+        Optional<Transaction> retrieved = transactionRepository.findById(saved.getId());
+        assertNotNull(retrieved.orElse(null));
+        assertNull(retrieved.get().getFileUpload());
+    }
+
+    @Test
+    void csvImportedTransactionStillRequiresAndLinksAFileUpload() {
+        BankAccount account = accountRepository.save(
+                new BankAccount("Current Account", "SORTCODE", "ACCNUMBER", new BigDecimal(2000), LocalDate.now()));
+
+        FileUpload fileUpload = new FileUpload("statement.csv", account);
+        fileUploadRepository.save(fileUpload);
+
+        Transaction transaction = new Transaction(
+                "31/03/2022", account, BigDecimal.valueOf(-9), "Debit", "BAR BRUNO", "ON 29 MAR CPM");
+        transaction.setFileUpload(fileUpload);
+
+        Transaction saved = transactionRepository.saveAndFlush(transaction);
+
+        Optional<Transaction> retrieved = transactionRepository.findById(saved.getId());
+        assertNotNull(retrieved.orElse(null));
+        assertNotNull(retrieved.get().getFileUpload());
+        assertEquals(fileUpload.getId(), retrieved.get().getFileUpload().getId());
+    }
+}

--- a/fm-backend/src/test/java/com/service/AccountServiceTest.java
+++ b/fm-backend/src/test/java/com/service/AccountServiceTest.java
@@ -6,6 +6,7 @@ import com.repository.TransactionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -18,11 +19,17 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+// Note: this test previously called `new AccountService(accountRepository, transactionRepository,
+// financeManagerService)`, but AccountService only has a no-arg constructor (it uses field
+// injection) - that call never compiled. Pre-existing breakage found on this branch while working
+// FM-23, unrelated to FM-23 itself; fixed here (switched to @InjectMocks, the idiomatic Mockito
+// equivalent of the field-injection wiring AccountService already uses) only so the module's test
+// suite compiles and can actually be run.
 @ExtendWith(MockitoExtension.class)
 public class AccountServiceTest {
 
+    @InjectMocks
     private AccountService service;
-    private FinanceManagerService financeManagerService;
 
     @Mock
     private AccountRepository accountRepository;
@@ -30,11 +37,12 @@ public class AccountServiceTest {
     @Mock
     private TransactionRepository transactionRepository;
 
+    @Mock
+    private FinanceManagerService financeManagerService;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        service = new AccountService(accountRepository, transactionRepository, financeManagerService);
     }
 
     @Test

--- a/fm-backend/src/test/java/com/service/FinanceManagerServiceTest.java
+++ b/fm-backend/src/test/java/com/service/FinanceManagerServiceTest.java
@@ -4,13 +4,20 @@ import com.helper.CSVHelper;
 import com.repository.TransactionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+// Note: this test previously called `new FinanceManagerService(repository)`, but
+// FinanceManagerService only has a no-arg constructor (it uses field injection) - that call never
+// compiled. Pre-existing breakage found on this branch while working FM-23, unrelated to FM-23
+// itself; fixed here (switched to @InjectMocks) only so the module's test suite compiles and can
+// actually be run.
 public class FinanceManagerServiceTest {
 
+    @InjectMocks
     private FinanceManagerService service;
 
     @Mock
@@ -20,7 +27,6 @@ public class FinanceManagerServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        service = new FinanceManagerService(repository);
     }
 
 }

--- a/fm-backend/src/test/java/com/service/TransactionServiceTest.java
+++ b/fm-backend/src/test/java/com/service/TransactionServiceTest.java
@@ -2,37 +2,48 @@ package com.service;
 
 import com.dto.BankAccount;
 import com.dto.Transaction;
-import com.helper.CSVHelper;
+import com.dto.request.NewTransactionRequest;
+import com.dto.response.TransactionResponse;
+import com.repository.AccountRepository;
 import com.repository.TransactionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class TransactionServiceTest {
 
+    @InjectMocks
     private TransactionService service;
 
     @Mock
     private TransactionRepository repository;
 
     @Mock
-    private CSVHelper csvHelper;
+    private AccountRepository accountRepository;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        service = new TransactionService();
     }
 
     @Test
@@ -53,4 +64,152 @@ public class TransactionServiceTest {
         assertEquals(2, actualResult.size());
     }
 
+    private BankAccount accountWithId(int id) {
+        BankAccount account = new BankAccount("Current Account", "SORTCODE", "ACCNUMBER", new BigDecimal(1000), LocalDate.now());
+        account.setId(id);
+        return account;
+    }
+
+    private NewTransactionRequest validRequest() {
+        return new NewTransactionRequest(LocalDate.now(), 1, BigDecimal.valueOf(-25.50), "Groceries", "Tesco", "Weekly shop");
+    }
+
+    // AC §8 backend #3 - fully valid payload -> saved transaction returned, including generated id.
+    @Test
+    public void validPayloadIsSavedAndReturnedWithGeneratedId() {
+        BankAccount account = accountWithId(1);
+        when(accountRepository.findById(1)).thenReturn(Optional.of(account));
+
+        ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(Transaction.class);
+        when(repository.save(captor.capture())).thenAnswer(invocation -> {
+            Transaction toSave = invocation.getArgument(0);
+            toSave.setId(42);
+            return toSave;
+        });
+
+        TransactionResponse response = service.addManualTransaction(validRequest());
+
+        assertEquals(42, response.id());
+        assertEquals(account.getId(), response.account().id());
+        assertEquals(account.getName(), response.account().name());
+        assertEquals(BigDecimal.valueOf(-25.50), response.amount());
+        assertEquals("Groceries", response.category());
+        assertEquals("Tesco", response.paid_to());
+        assertEquals("Weekly shop", response.memo());
+    }
+
+    // AC §8 backend #4 - missing/blank amount -> 400 (IllegalArgumentException from the service).
+    @Test
+    public void missingAmountIsRejected() {
+        NewTransactionRequest request = new NewTransactionRequest(LocalDate.now(), 1, null, "Groceries", "Tesco", null);
+
+        assertThrows(IllegalArgumentException.class, () -> service.addManualTransaction(request));
+        verify(repository, never()).save(any());
+    }
+
+    // AC §8 backend #4 - missing/blank paid_to -> 400.
+    @Test
+    public void blankPaidToIsRejected() {
+        NewTransactionRequest request = new NewTransactionRequest(LocalDate.now(), 1, BigDecimal.TEN, "Groceries", "  ", null);
+
+        assertThrows(IllegalArgumentException.class, () -> service.addManualTransaction(request));
+        verify(repository, never()).save(any());
+    }
+
+    // AC §8 backend #4 - missing/null date -> 400.
+    @Test
+    public void missingDateIsRejected() {
+        NewTransactionRequest request = new NewTransactionRequest(null, 1, BigDecimal.TEN, "Groceries", "Tesco", null);
+
+        assertThrows(IllegalArgumentException.class, () -> service.addManualTransaction(request));
+        verify(repository, never()).save(any());
+    }
+
+    // AC §8 backend #4/#7 - accountId not matching any existing BankAccount -> 400.
+    // This also covers "missing accountId": a JSON payload with no accountId deserializes the
+    // primitive int field to 0, which will never match a real (sequence-generated, 1-based) id.
+    @Test
+    public void nonExistentAccountIdIsRejected() {
+        when(accountRepository.findById(999)).thenReturn(Optional.empty());
+        NewTransactionRequest request = new NewTransactionRequest(LocalDate.now(), 999, BigDecimal.TEN, "Groceries", "Tesco", null);
+
+        assertThrows(IllegalArgumentException.class, () -> service.addManualTransaction(request));
+        verify(repository, never()).save(any());
+    }
+
+    // AC §8 backend #5 - amount == 0 -> 400.
+    @Test
+    public void zeroAmountIsRejected() {
+        NewTransactionRequest request = new NewTransactionRequest(LocalDate.now(), 1, BigDecimal.ZERO, "Groceries", "Tesco", null);
+
+        assertThrows(IllegalArgumentException.class, () -> service.addManualTransaction(request));
+        verify(repository, never()).save(any());
+    }
+
+    // AC §8 backend #6 - date in the future -> 400.
+    @Test
+    public void futureDateIsRejected() {
+        NewTransactionRequest request = new NewTransactionRequest(LocalDate.now().plusDays(1), 1, BigDecimal.TEN, "Groceries", "Tesco", null);
+
+        assertThrows(IllegalArgumentException.class, () -> service.addManualTransaction(request));
+        verify(repository, never()).save(any());
+    }
+
+    // AC §8 backend #8 - segment selected -> category = segment name, segment column unaffected ("Undefined").
+    @Test
+    public void categoryIsSetFromSelectedSegmentAndSegmentColumnStaysUndefined() {
+        BankAccount account = accountWithId(1);
+        when(accountRepository.findById(1)).thenReturn(Optional.of(account));
+        when(repository.save(any(Transaction.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NewTransactionRequest request = new NewTransactionRequest(LocalDate.now(), 1, BigDecimal.TEN, "Groceries", "Tesco", null);
+        TransactionResponse response = service.addManualTransaction(request);
+
+        ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(Transaction.class);
+        verify(repository).save(captor.capture());
+        assertEquals("Groceries", response.category());
+        assertEquals("Undefined", captor.getValue().getSegment());
+    }
+
+    // AC §8 backend #9 - no segment selected -> category null/blank, segment column unaffected.
+    @Test
+    public void noSegmentSelectedLeavesCategoryNullAndSegmentUndefined() {
+        BankAccount account = accountWithId(1);
+        when(accountRepository.findById(1)).thenReturn(Optional.of(account));
+        when(repository.save(any(Transaction.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NewTransactionRequest request = new NewTransactionRequest(LocalDate.now(), 1, BigDecimal.TEN, null, "Tesco", null);
+        TransactionResponse response = service.addManualTransaction(request);
+
+        ArgumentCaptor<Transaction> captor = ArgumentCaptor.forClass(Transaction.class);
+        verify(repository).save(captor.capture());
+        assertNull(response.category());
+        assertEquals("Undefined", captor.getValue().getSegment());
+    }
+
+    // AC §8 backend #10 - memo omitted -> saves without error.
+    @Test
+    public void memoIsOptional() {
+        BankAccount account = accountWithId(1);
+        when(accountRepository.findById(1)).thenReturn(Optional.of(account));
+        when(repository.save(any(Transaction.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NewTransactionRequest request = new NewTransactionRequest(LocalDate.now(), 1, BigDecimal.TEN, "Groceries", "Tesco", null);
+        TransactionResponse response = service.addManualTransaction(request);
+
+        assertNull(response.memo());
+    }
+
+    // AC §8 backend #11 - negative amount accepted and persisted as-is (money-out case).
+    @Test
+    public void negativeAmountIsAcceptedAsIs() {
+        BankAccount account = accountWithId(1);
+        when(accountRepository.findById(1)).thenReturn(Optional.of(account));
+        when(repository.save(any(Transaction.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NewTransactionRequest request = new NewTransactionRequest(LocalDate.now(), 1, BigDecimal.valueOf(-42.10), "Groceries", "Tesco", null);
+        TransactionResponse response = service.addManualTransaction(request);
+
+        assertEquals(BigDecimal.valueOf(-42.10), response.amount());
+    }
 }

--- a/fm-backend/src/test/java/com/service/TransactionServiceTest.java
+++ b/fm-backend/src/test/java/com/service/TransactionServiceTest.java
@@ -125,9 +125,7 @@ public class TransactionServiceTest {
         verify(repository, never()).save(any());
     }
 
-    // AC §8 backend #4/#7 - accountId not matching any existing BankAccount -> 400.
-    // This also covers "missing accountId": a JSON payload with no accountId deserializes the
-    // primitive int field to 0, which will never match a real (sequence-generated, 1-based) id.
+    // AC §8 backend #7 - accountId not matching any existing BankAccount -> 400.
     @Test
     public void nonExistentAccountIdIsRejected() {
         when(accountRepository.findById(999)).thenReturn(Optional.empty());
@@ -135,6 +133,18 @@ public class TransactionServiceTest {
 
         assertThrows(IllegalArgumentException.class, () -> service.addManualTransaction(request));
         verify(repository, never()).save(any());
+    }
+
+    // AC §8 backend #4 - missing accountId (null, e.g. JSON payload omits the key entirely) -> 400,
+    // handled by its own explicit check rather than accidentally falling through to
+    // accountRepository.findById(null)/"account does not exist".
+    @Test
+    public void missingAccountIdIsRejected() {
+        NewTransactionRequest request = new NewTransactionRequest(LocalDate.now(), null, BigDecimal.TEN, "Groceries", "Tesco", null);
+
+        assertThrows(IllegalArgumentException.class, () -> service.addManualTransaction(request));
+        verify(repository, never()).save(any());
+        verify(accountRepository, never()).findById(any());
     }
 
     // AC §8 backend #5 - amount == 0 -> 400.

--- a/fm-backend/src/test/resources/application.yml
+++ b/fm-backend/src/test/resources/application.yml
@@ -1,0 +1,23 @@
+server:
+  port: 8080
+
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+    show-sql: true
+  main:
+    web-application-type: servlet
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB

--- a/fm-ui/src/App.js
+++ b/fm-ui/src/App.js
@@ -12,6 +12,7 @@ import Segments from "./pages/Segments";
 import EditAccount from "./pages/EditAccount";
 import UploadHistory from "./pages/UploadHistory";
 import ViewUpload from "./pages/ViewUpload";
+import AddTransaction from "./pages/AddTransaction";
 
 class App extends Component {
   state = {};
@@ -36,6 +37,7 @@ class App extends Component {
               />
               <Route path="/uploadHistory" element={<UploadHistory />} />
               <Route path="/uploadHistory/:id" element={<ViewUpload />} />
+              <Route path="/addTransaction" element={<AddTransaction />} />
               <Route path="/accounts" element={<AccountsPage />} />
               <Route path="/account" element={<CreateNewAccount />} />
               <Route path="/segments" element={<Segments />} />

--- a/fm-ui/src/components/AddTransactionForm.jsx
+++ b/fm-ui/src/components/AddTransactionForm.jsx
@@ -1,0 +1,309 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Alert, Button, Form } from "react-bootstrap";
+import { BACKEND_URL } from "../config";
+import { formatIsoDateForDisplay, getTodayIsoDate } from "../helpers/utils";
+
+const BLANK_FORM = {
+  date: "",
+  amount: "",
+  accountId: "",
+  paidTo: "",
+  direction: "",
+  segment: "",
+  memo: "",
+};
+
+function AddTransactionForm({ accounts }) {
+  const navigate = useNavigate();
+  const [segments, setSegments] = useState([]);
+  const [form, setForm] = useState(BLANK_FORM);
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [view, setView] = useState("form"); // "form" | "success" | "error"
+  const [savedTransaction, setSavedTransaction] = useState(null);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    fetch(`${BACKEND_URL}/segments`)
+      .then((response) => response.json())
+      .then((data) => setSegments(data))
+      .catch(() => setSegments([]));
+  }, []);
+
+  const clearFieldError = (field) => {
+    setFieldErrors((previous) => {
+      const { [field]: _removed, ...rest } = previous;
+      return rest;
+    });
+  };
+
+  const updateField = (field) => (event) => {
+    setForm((previous) => ({ ...previous, [field]: event.target.value }));
+    clearFieldError(field);
+  };
+
+  const handleDirectionChange = (direction) => {
+    setForm((previous) => ({ ...previous, direction }));
+    clearFieldError("direction");
+  };
+
+  const validate = () => {
+    const errors = {};
+
+    const magnitude = parseFloat(form.amount);
+    if (form.amount === "" || Number.isNaN(magnitude)) {
+      errors.amount = "Enter an amount.";
+    } else if (magnitude <= 0) {
+      errors.amount = "Enter an amount greater than 0.";
+    }
+
+    if (!form.accountId) {
+      errors.accountId = "Select an account.";
+    } else if (!accounts.some((account) => String(account.id) === form.accountId)) {
+      errors.accountId = "Select a valid account.";
+    }
+
+    if (!form.paidTo.trim()) {
+      errors.paidTo = "Enter who was paid or who paid you.";
+    }
+
+    if (form.direction !== "in" && form.direction !== "out") {
+      errors.direction = "Select whether money came in or went out.";
+    }
+
+    if (!form.date) {
+      errors.date = "Enter a date.";
+    } else if (form.date > getTodayIsoDate()) {
+      errors.date = "Date cannot be in the future.";
+    }
+
+    return errors;
+  };
+
+  const buildPayload = () => {
+    const magnitude = Math.abs(parseFloat(form.amount));
+    const signedAmount = form.direction === "out" ? -magnitude : magnitude;
+
+    return {
+      date: form.date,
+      accountId: parseInt(form.accountId, 10),
+      amount: signedAmount,
+      category: form.segment || null,
+      paid_to: form.paidTo.trim(),
+      memo: form.memo.trim() || null,
+    };
+  };
+
+  const resetForm = () => {
+    setForm(BLANK_FORM);
+    setFieldErrors({});
+    setSavedTransaction(null);
+    setErrorMessage("");
+    setView("form");
+  };
+
+  const onSubmit = async () => {
+    const errors = validate();
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    try {
+      const response = await fetch(`${BACKEND_URL}/transactions/transaction`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildPayload()),
+      });
+
+      if (response.status === 201) {
+        const data = await response.json();
+        setSavedTransaction(data);
+        setView("success");
+        return;
+      }
+
+      setErrorMessage(
+        "We couldn't save this transaction. Please check the details and try again."
+      );
+      setView("error");
+    } catch (error) {
+      setErrorMessage(
+        "We couldn't reach the server. Please check your connection and try again."
+      );
+      setView("error");
+    }
+  };
+
+  if (view === "success" && savedTransaction) {
+    const amount = Number(savedTransaction.amount);
+    const sign = amount > 0 ? "+" : "";
+    const accountName = savedTransaction.account?.name ?? "Unknown account";
+
+    return (
+      <div>
+        <Alert variant="success">
+          <Alert.Heading>Transaction added</Alert.Heading>
+          <p className="mb-1">
+            Amount: {sign}
+            {amount.toFixed(2)}
+          </p>
+          <p className="mb-1">Account: {accountName}</p>
+          <p className="mb-1">Paid to: {savedTransaction.paid_to}</p>
+          <p className="mb-1">
+            Segment: {savedTransaction.category || "None"}
+          </p>
+          <p className="mb-1">
+            Date: {formatIsoDateForDisplay(savedTransaction.date)}
+          </p>
+          {savedTransaction.memo && (
+            <p className="mb-0">Memo: {savedTransaction.memo}</p>
+          )}
+        </Alert>
+        <Button variant="primary" className="me-2" onClick={resetForm}>
+          Add another transaction
+        </Button>
+        <Button variant="secondary" onClick={() => navigate("/")}>
+          Return to dashboard
+        </Button>
+      </div>
+    );
+  }
+
+  if (view === "error") {
+    return (
+      <div>
+        <Alert variant="danger">
+          <Alert.Heading>Couldn't save transaction</Alert.Heading>
+          <p className="mb-0">{errorMessage}</p>
+        </Alert>
+        <Button variant="primary" onClick={() => setView("form")}>
+          Back to form
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <Form>
+      <Form.Group className="mb-3" controlId="formAmount">
+        <Form.Label>Amount</Form.Label>
+        <Form.Control
+          type="number"
+          step="0.01"
+          value={form.amount}
+          onChange={updateField("amount")}
+          isInvalid={!!fieldErrors.amount}
+        />
+        <Form.Control.Feedback type="invalid">
+          {fieldErrors.amount}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3" controlId="formDirection">
+        <Form.Label>Money in or out</Form.Label>
+        <div>
+          <Form.Check
+            inline
+            type="radio"
+            label="Money in"
+            name="direction"
+            id="direction-in"
+            checked={form.direction === "in"}
+            onChange={() => handleDirectionChange("in")}
+            isInvalid={!!fieldErrors.direction}
+          />
+          <Form.Check
+            inline
+            type="radio"
+            label="Money out"
+            name="direction"
+            id="direction-out"
+            checked={form.direction === "out"}
+            onChange={() => handleDirectionChange("out")}
+            isInvalid={!!fieldErrors.direction}
+          />
+        </div>
+        {fieldErrors.direction && (
+          <div className="invalid-feedback d-block">
+            {fieldErrors.direction}
+          </div>
+        )}
+      </Form.Group>
+
+      <Form.Group className="mb-3" controlId="formAccount">
+        <Form.Label>Account</Form.Label>
+        <Form.Select
+          value={form.accountId}
+          onChange={updateField("accountId")}
+          isInvalid={!!fieldErrors.accountId}
+        >
+          <option value="">Select an account</option>
+          {accounts.map((account) => (
+            <option value={account.id} key={account.id}>
+              {account.name}
+            </option>
+          ))}
+        </Form.Select>
+        <Form.Control.Feedback type="invalid">
+          {fieldErrors.accountId}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3" controlId="formPaidTo">
+        <Form.Label>Paid to</Form.Label>
+        <Form.Control
+          type="text"
+          value={form.paidTo}
+          onChange={updateField("paidTo")}
+          isInvalid={!!fieldErrors.paidTo}
+        />
+        <Form.Control.Feedback type="invalid">
+          {fieldErrors.paidTo}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3" controlId="formSegment">
+        <Form.Label>Segment</Form.Label>
+        <Form.Select value={form.segment} onChange={updateField("segment")}>
+          <option value="">No segment</option>
+          {segments.map((segment) => (
+            <option value={segment.name} key={segment.id}>
+              {segment.name}
+            </option>
+          ))}
+        </Form.Select>
+      </Form.Group>
+
+      <Form.Group className="mb-3" controlId="formDate">
+        <Form.Label>Date</Form.Label>
+        <Form.Control
+          type="date"
+          value={form.date}
+          max={getTodayIsoDate()}
+          onChange={updateField("date")}
+          isInvalid={!!fieldErrors.date}
+        />
+        <Form.Control.Feedback type="invalid">
+          {fieldErrors.date}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3" controlId="formMemo">
+        <Form.Label>Memo</Form.Label>
+        <Form.Control
+          as="textarea"
+          rows={2}
+          value={form.memo}
+          onChange={updateField("memo")}
+        />
+      </Form.Group>
+
+      <Button variant="primary" type="button" onClick={onSubmit}>
+        Add transaction
+      </Button>
+    </Form>
+  );
+}
+
+export default AddTransactionForm;

--- a/fm-ui/src/components/AddTransactionForm.jsx
+++ b/fm-ui/src/components/AddTransactionForm.jsx
@@ -123,9 +123,15 @@ function AddTransactionForm({ accounts }) {
         return;
       }
 
-      setErrorMessage(
-        "We couldn't save this transaction. Please check the details and try again."
-      );
+      const genericMessage =
+        "We couldn't save this transaction. Please check the details and try again.";
+      let reason = "";
+      try {
+        reason = (await response.text()).trim();
+      } catch (readError) {
+        reason = "";
+      }
+      setErrorMessage(reason || genericMessage);
       setView("error");
     } catch (error) {
       setErrorMessage(
@@ -200,8 +206,14 @@ function AddTransactionForm({ accounts }) {
         </Form.Control.Feedback>
       </Form.Group>
 
-      <Form.Group className="mb-3" controlId="formDirection">
-        <Form.Label>Money in or out</Form.Label>
+      <Form.Group
+        className="mb-3"
+        as="fieldset"
+        aria-describedby={
+          fieldErrors.direction ? "direction-error" : undefined
+        }
+      >
+        <Form.Label as="legend">Money in or out</Form.Label>
         <div>
           <Form.Check
             inline
@@ -225,7 +237,7 @@ function AddTransactionForm({ accounts }) {
           />
         </div>
         {fieldErrors.direction && (
-          <div className="invalid-feedback d-block">
+          <div className="invalid-feedback d-block" id="direction-error">
             {fieldErrors.direction}
           </div>
         )}

--- a/fm-ui/src/components/AddTransactionForm.test.jsx
+++ b/fm-ui/src/components/AddTransactionForm.test.jsx
@@ -18,11 +18,20 @@ const segments = [
   { id: 11, name: "Bills" },
 ];
 
+function textFor(body) {
+  if (typeof body === "string") return body;
+  if (body && typeof body === "object" && Object.keys(body).length > 0) {
+    return JSON.stringify(body);
+  }
+  return "";
+}
+
 function jsonResponse(status, body) {
   return Promise.resolve({
     status,
     ok: status >= 200 && status < 300,
     json: () => Promise.resolve(body),
+    text: () => Promise.resolve(textFor(body)),
   });
 }
 
@@ -158,9 +167,11 @@ test("selecting money out sends a negative amount; money in sends a positive amo
 });
 
 test("successful submit shows the success view with correct details and both actions wired", async () => {
+  let lastBody = null;
   setupFetchMock({
-    onSubmit: () =>
-      jsonResponse(201, {
+    onSubmit: (options) => {
+      lastBody = JSON.parse(options.body);
+      return jsonResponse(201, {
         id: 42,
         date: "2020-01-15",
         account: { id: 1, name: "Current Account" },
@@ -168,7 +179,8 @@ test("successful submit shows the success view with correct details and both act
         category: "Groceries",
         paid_to: "Tesco",
         memo: "Weekly shop",
-      }),
+      });
+    },
   });
   render(<AddTransactionForm accounts={accounts} />);
   await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
@@ -179,6 +191,8 @@ test("successful submit shows the success view with correct details and both act
   await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
 
   await waitFor(() => expect(screen.getByText("Transaction added")).toBeInTheDocument());
+  expect(lastBody).not.toBeNull();
+  expect(lastBody.amount).toBe(25.5);
   expect(screen.getByText(/Amount: \+25.50/)).toBeInTheDocument();
   expect(screen.getByText(/Account: Current Account/)).toBeInTheDocument();
   expect(screen.getByText(/Paid to: Tesco/)).toBeInTheDocument();
@@ -230,6 +244,28 @@ test("backend 400 shows the dedicated error view, distinct from inline field val
     expect(screen.getByText("Couldn't save transaction")).toBeInTheDocument()
   );
   expect(screen.getByRole("button", { name: "Back to form" })).toBeInTheDocument();
+});
+
+test("backend 400 with a specific reason surfaces that reason instead of the generic message", async () => {
+  setupFetchMock({
+    onSubmit: () =>
+      Promise.resolve({
+        status: 400,
+        ok: false,
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve("Amount cannot be zero"),
+      }),
+  });
+  render(<AddTransactionForm accounts={accounts} />);
+  await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
+
+  await fillValidForm();
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+
+  await waitFor(() =>
+    expect(screen.getByText("Couldn't save transaction")).toBeInTheDocument()
+  );
+  expect(screen.getByText("Amount cannot be zero")).toBeInTheDocument();
 });
 
 test("network failure on submit shows the dedicated error view", async () => {

--- a/fm-ui/src/components/AddTransactionForm.test.jsx
+++ b/fm-ui/src/components/AddTransactionForm.test.jsx
@@ -1,0 +1,278 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AddTransactionForm from "./AddTransactionForm";
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+const accounts = [
+  { id: 1, name: "Current Account" },
+  { id: 2, name: "Savings Account" },
+];
+
+const segments = [
+  { id: 10, name: "Groceries" },
+  { id: 11, name: "Bills" },
+];
+
+function jsonResponse(status, body) {
+  return Promise.resolve({
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body),
+  });
+}
+
+// Routes fetch calls by URL/method so tests don't depend on call order.
+function setupFetchMock({ onSubmit } = {}) {
+  global.fetch = jest.fn((url, options) => {
+    if (url.endsWith("/segments") && !options) {
+      return jsonResponse(200, segments);
+    }
+    if (url.endsWith("/transactions/transaction") && options?.method === "POST") {
+      return onSubmit ? onSubmit(options) : jsonResponse(201, {});
+    }
+    return jsonResponse(200, []);
+  });
+}
+
+async function fillValidForm({ direction = "in", amount = "25.50" } = {}) {
+  await userEvent.type(screen.getByLabelText("Amount"), amount);
+  await userEvent.click(
+    screen.getByLabelText(direction === "in" ? "Money in" : "Money out")
+  );
+  await userEvent.selectOptions(screen.getByLabelText("Account"), "1");
+  await userEvent.type(screen.getByLabelText("Paid to"), "Tesco");
+  await userEvent.type(screen.getByLabelText("Date"), "2020-01-15");
+}
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+});
+
+test("populates account dropdown from props and segment dropdown from GET /segments with a no-segment option", async () => {
+  setupFetchMock();
+  render(<AddTransactionForm accounts={accounts} />);
+
+  expect(screen.getByRole("option", { name: "Current Account" })).toBeInTheDocument();
+  expect(screen.getByRole("option", { name: "Savings Account" })).toBeInTheDocument();
+
+  await waitFor(() =>
+    expect(screen.getByRole("option", { name: "Groceries" })).toBeInTheDocument()
+  );
+  expect(screen.getByRole("option", { name: "Bills" })).toBeInTheDocument();
+  expect(screen.getByRole("option", { name: "No segment" })).toBeInTheDocument();
+});
+
+test("submitting with each required field missing shows inline validation only for that field, no error view", async () => {
+  setupFetchMock();
+  render(<AddTransactionForm accounts={accounts} />);
+  await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
+
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+
+  expect(screen.getByText("Enter an amount.")).toBeInTheDocument();
+  expect(
+    screen.getByText("Select whether money came in or went out.")
+  ).toBeInTheDocument();
+  expect(screen.getByText("Select an account.")).toBeInTheDocument();
+  expect(screen.getByText("Enter who was paid or who paid you.")).toBeInTheDocument();
+  expect(screen.getByText("Enter a date.")).toBeInTheDocument();
+
+  // Must not have swapped to the dedicated error view.
+  expect(screen.queryByText("Couldn't save transaction")).not.toBeInTheDocument();
+  expect(global.fetch).not.toHaveBeenCalledWith(
+    expect.stringContaining("/transactions/transaction"),
+    expect.anything()
+  );
+
+  // Fixing one field clears only that field's error.
+  await userEvent.type(screen.getByLabelText("Amount"), "10");
+  expect(screen.queryByText("Enter an amount.")).not.toBeInTheDocument();
+  expect(screen.getByText("Select an account.")).toBeInTheDocument();
+});
+
+test("zero or negative amount is blocked with inline validation before submit", async () => {
+  setupFetchMock();
+  render(<AddTransactionForm accounts={accounts} />);
+  await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
+
+  await userEvent.type(screen.getByLabelText("Amount"), "0");
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+  expect(screen.getByText("Enter an amount greater than 0.")).toBeInTheDocument();
+
+  await userEvent.clear(screen.getByLabelText("Amount"));
+  await userEvent.type(screen.getByLabelText("Amount"), "-5");
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+  expect(screen.getByText("Enter an amount greater than 0.")).toBeInTheDocument();
+
+  expect(global.fetch).not.toHaveBeenCalledWith(
+    expect.stringContaining("/transactions/transaction"),
+    expect.anything()
+  );
+});
+
+test("future date is blocked with inline validation before submit", async () => {
+  setupFetchMock();
+  render(<AddTransactionForm accounts={accounts} />);
+  await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
+
+  const futureYear = new Date().getFullYear() + 1;
+  await userEvent.type(screen.getByLabelText("Date"), `${futureYear}-01-01`);
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+
+  expect(screen.getByText("Date cannot be in the future.")).toBeInTheDocument();
+  expect(global.fetch).not.toHaveBeenCalledWith(
+    expect.stringContaining("/transactions/transaction"),
+    expect.anything()
+  );
+});
+
+test("selecting money out sends a negative amount; money in sends a positive amount", async () => {
+  let lastBody = null;
+  setupFetchMock({
+    onSubmit: (options) => {
+      lastBody = JSON.parse(options.body);
+      return jsonResponse(201, {
+        id: 1,
+        date: "2020-01-15",
+        account: { id: 1, name: "Current Account" },
+        amount: lastBody.amount,
+        category: null,
+        paid_to: "Tesco",
+        memo: null,
+      });
+    },
+  });
+  render(<AddTransactionForm accounts={accounts} />);
+  await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
+
+  await fillValidForm({ direction: "out", amount: "25.50" });
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+
+  await waitFor(() => expect(lastBody).not.toBeNull());
+  expect(lastBody.amount).toBe(-25.5);
+});
+
+test("successful submit shows the success view with correct details and both actions wired", async () => {
+  setupFetchMock({
+    onSubmit: () =>
+      jsonResponse(201, {
+        id: 42,
+        date: "2020-01-15",
+        account: { id: 1, name: "Current Account" },
+        amount: 25.5,
+        category: "Groceries",
+        paid_to: "Tesco",
+        memo: "Weekly shop",
+      }),
+  });
+  render(<AddTransactionForm accounts={accounts} />);
+  await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
+
+  await fillValidForm({ direction: "in", amount: "25.50" });
+  await userEvent.selectOptions(screen.getByLabelText("Segment"), "Groceries");
+  await userEvent.type(screen.getByLabelText("Memo"), "Weekly shop");
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+
+  await waitFor(() => expect(screen.getByText("Transaction added")).toBeInTheDocument());
+  expect(screen.getByText(/Amount: \+25.50/)).toBeInTheDocument();
+  expect(screen.getByText(/Account: Current Account/)).toBeInTheDocument();
+  expect(screen.getByText(/Paid to: Tesco/)).toBeInTheDocument();
+  expect(screen.getByText(/Segment: Groceries/)).toBeInTheDocument();
+  expect(screen.getByText(/Date: 15\/01\/2020/)).toBeInTheDocument();
+  expect(screen.getByText(/Memo: Weekly shop/)).toBeInTheDocument();
+
+  // "Return to dashboard" navigates home.
+  await userEvent.click(screen.getByRole("button", { name: "Return to dashboard" }));
+  expect(mockNavigate).toHaveBeenCalledWith("/");
+});
+
+test("'Add another transaction' resets to a blank form on the same page", async () => {
+  setupFetchMock({
+    onSubmit: () =>
+      jsonResponse(201, {
+        id: 1,
+        date: "2020-01-15",
+        account: { id: 1, name: "Current Account" },
+        amount: 25.5,
+        category: null,
+        paid_to: "Tesco",
+        memo: null,
+      }),
+  });
+  render(<AddTransactionForm accounts={accounts} />);
+  await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
+
+  await fillValidForm();
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+  await waitFor(() => expect(screen.getByText("Transaction added")).toBeInTheDocument());
+
+  await userEvent.click(screen.getByRole("button", { name: "Add another transaction" }));
+
+  expect(screen.getByLabelText("Amount")).toHaveValue(null);
+  expect(screen.getByLabelText("Paid to")).toHaveValue("");
+  expect(screen.queryByText("Transaction added")).not.toBeInTheDocument();
+});
+
+test("backend 400 shows the dedicated error view, distinct from inline field validation", async () => {
+  setupFetchMock({ onSubmit: () => jsonResponse(400, {}) });
+  render(<AddTransactionForm accounts={accounts} />);
+  await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
+
+  await fillValidForm();
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+
+  await waitFor(() =>
+    expect(screen.getByText("Couldn't save transaction")).toBeInTheDocument()
+  );
+  expect(screen.getByRole("button", { name: "Back to form" })).toBeInTheDocument();
+});
+
+test("network failure on submit shows the dedicated error view", async () => {
+  setupFetchMock({ onSubmit: () => Promise.reject(new Error("network down")) });
+  render(<AddTransactionForm accounts={accounts} />);
+  await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
+
+  await fillValidForm();
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+
+  await waitFor(() =>
+    expect(screen.getByText("Couldn't save transaction")).toBeInTheDocument()
+  );
+});
+
+test("duplicate transaction (same amount/payee/date submitted twice) succeeds both times", async () => {
+  setupFetchMock({
+    onSubmit: () =>
+      jsonResponse(201, {
+        id: 1,
+        date: "2020-01-15",
+        account: { id: 1, name: "Current Account" },
+        amount: 25.5,
+        category: null,
+        paid_to: "Tesco",
+        memo: null,
+      }),
+  });
+  render(<AddTransactionForm accounts={accounts} />);
+  await waitFor(() => screen.getByRole("option", { name: "Groceries" }));
+
+  await fillValidForm();
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+  await waitFor(() => expect(screen.getByText("Transaction added")).toBeInTheDocument());
+
+  await userEvent.click(screen.getByRole("button", { name: "Add another transaction" }));
+  await fillValidForm();
+  await userEvent.click(screen.getByRole("button", { name: "Add transaction" }));
+
+  await waitFor(() => expect(screen.getByText("Transaction added")).toBeInTheDocument());
+
+  const submitCalls = global.fetch.mock.calls.filter(([url, options]) =>
+    url.endsWith("/transactions/transaction") && options?.method === "POST"
+  );
+  expect(submitCalls).toHaveLength(2);
+});

--- a/fm-ui/src/components/general/Navbar.jsx
+++ b/fm-ui/src/components/general/Navbar.jsx
@@ -1,9 +1,26 @@
+import { useEffect, useState } from "react";
 import Container from "react-bootstrap/Container";
 import Nav from "react-bootstrap/Nav";
 import Navbar from "react-bootstrap/Navbar";
 import { NavDropdown } from "react-bootstrap";
+import { BACKEND_URL } from "../../config";
+
+const NO_ACCOUNTS_MESSAGE = "Add a bank account first to add a transaction";
 
 function NavigationBar() {
+  // Assume accounts exist until proven otherwise, so the link doesn't
+  // flash disabled on every page load while the accounts fetch is in
+  // flight. The page itself (§5) independently re-enforces this gate,
+  // so a click during that brief window is still safe.
+  const [hasAccounts, setHasAccounts] = useState(true);
+
+  useEffect(() => {
+    fetch(`${BACKEND_URL}/accounts`)
+      .then((response) => response.json())
+      .then((data) => setHasAccounts(Array.isArray(data) && data.length > 0))
+      .catch(() => setHasAccounts(true));
+  }, []);
+
   return (
     <>
       <Navbar expand="lg" bg="dark" variant="dark">
@@ -22,6 +39,19 @@ function NavigationBar() {
                 <NavDropdown.Item href="/uploadTransactions">
                   Upload Transactions
                 </NavDropdown.Item>
+                <NavDropdown.Divider />
+                {hasAccounts ? (
+                  <NavDropdown.Item href="/addTransaction">
+                    Add Transaction
+                  </NavDropdown.Item>
+                ) : (
+                  <NavDropdown.Item disabled title={NO_ACCOUNTS_MESSAGE}>
+                    Add Transaction
+                    <small className="text-muted d-block">
+                      {NO_ACCOUNTS_MESSAGE}
+                    </small>
+                  </NavDropdown.Item>
+                )}
               </NavDropdown>
               <Nav.Link href="/segments">Segments</Nav.Link>
             </Nav>

--- a/fm-ui/src/components/general/Navbar.jsx
+++ b/fm-ui/src/components/general/Navbar.jsx
@@ -45,7 +45,11 @@ function NavigationBar() {
                     Add Transaction
                   </NavDropdown.Item>
                 ) : (
-                  <NavDropdown.Item disabled title={NO_ACCOUNTS_MESSAGE}>
+                  <NavDropdown.Item
+                    as="a"
+                    disabled
+                    title={NO_ACCOUNTS_MESSAGE}
+                  >
                     Add Transaction
                     <small className="text-muted d-block">
                       {NO_ACCOUNTS_MESSAGE}

--- a/fm-ui/src/components/general/Navbar.test.jsx
+++ b/fm-ui/src/components/general/Navbar.test.jsx
@@ -26,6 +26,7 @@ test("zero accounts: nav entry point renders disabled with explanatory text", as
   await waitFor(() => {
     const link = screen.getByText("Add Transaction").closest("a");
     expect(link).toHaveClass("disabled");
+    expect(link).toHaveAttribute("aria-disabled", "true");
   });
   expect(
     screen.getByText("Add a bank account first to add a transaction")

--- a/fm-ui/src/components/general/Navbar.test.jsx
+++ b/fm-ui/src/components/general/Navbar.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NavigationBar from "./Navbar";
+
+function jsonResponse(status, body) {
+  return Promise.resolve({
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body),
+  });
+}
+
+function mockAccounts(accounts) {
+  global.fetch = jest.fn(() => jsonResponse(200, accounts));
+}
+
+test("zero accounts: nav entry point renders disabled with explanatory text", async () => {
+  mockAccounts([]);
+  render(<NavigationBar />);
+  // Wait for the accounts fetch to resolve and hasAccounts to flip to false
+  // before opening the dropdown, otherwise we can race the state update.
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+  await userEvent.click(screen.getByText("Transactions"));
+
+  await waitFor(() => {
+    const link = screen.getByText("Add Transaction").closest("a");
+    expect(link).toHaveClass("disabled");
+  });
+  expect(
+    screen.getByText("Add a bank account first to add a transaction")
+  ).toBeInTheDocument();
+});
+
+test("with accounts: nav entry point is an enabled link to /addTransaction", async () => {
+  mockAccounts([{ id: 1, name: "Current Account" }]);
+  render(<NavigationBar />);
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+  await userEvent.click(screen.getByText("Transactions"));
+
+  await waitFor(() => {
+    const link = screen.getByText("Add Transaction").closest("a");
+    expect(link).not.toHaveClass("disabled");
+    expect(link).toHaveAttribute("href", "/addTransaction");
+  });
+});

--- a/fm-ui/src/components/general/Navbar.test.jsx
+++ b/fm-ui/src/components/general/Navbar.test.jsx
@@ -46,3 +46,23 @@ test("with accounts: nav entry point is an enabled link to /addTransaction", asy
     expect(link).toHaveAttribute("href", "/addTransaction");
   });
 });
+
+// QA gap: the fetch-failure branch (GET /accounts rejecting) was untested.
+// Navbar deliberately "fails open" here (hasAccounts stays true) so a backend
+// hiccup doesn't block the entry point outright - the page-level gate (AC §5)
+// independently re-enforces the real check when /addTransaction actually
+// loads. This test pins down that documented fail-open behaviour so a future
+// change can't silently flip it without a test noticing.
+test("GET /accounts failing leaves the nav entry point enabled (fails open, page-level gate backstops it)", async () => {
+  global.fetch = jest.fn(() => Promise.reject(new Error("network down")));
+  render(<NavigationBar />);
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+  await userEvent.click(screen.getByText("Transactions"));
+
+  await waitFor(() => {
+    const link = screen.getByText("Add Transaction").closest("a");
+    expect(link).not.toHaveClass("disabled");
+    expect(link).toHaveAttribute("href", "/addTransaction");
+  });
+});

--- a/fm-ui/src/helpers/utils.jsx
+++ b/fm-ui/src/helpers/utils.jsx
@@ -4,4 +4,25 @@ function convertDateTime(date) {
   ).toLocaleTimeString()}`;
 }
 
-export { convertDateTime };
+// Returns today's date as a yyyy-MM-dd string, based on local time rather
+// than UTC, so it lines up with what a native <input type="date"> produces
+// and avoids the day-shift bug you get from new Date().toISOString().
+function getTodayIsoDate() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+// Formats an ISO (yyyy-MM-dd) date string as dd/MM/yyyy for display,
+// without constructing a Date object — avoids timezone-related day-shift
+// bugs when parsing a plain date (no time component) string.
+function formatIsoDateForDisplay(isoDate) {
+  if (!isoDate) return "";
+  const [year, month, day] = isoDate.split("-");
+  if (!year || !month || !day) return isoDate;
+  return `${day}/${month}/${year}`;
+}
+
+export { convertDateTime, getTodayIsoDate, formatIsoDateForDisplay };

--- a/fm-ui/src/pages/AddTransaction.jsx
+++ b/fm-ui/src/pages/AddTransaction.jsx
@@ -8,6 +8,7 @@ import AddTransactionForm from "../components/AddTransactionForm";
 function AddTransaction() {
   const [accounts, setAccounts] = useState([]);
   const [accountsLoaded, setAccountsLoaded] = useState(false);
+  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
     fetch(`${BACKEND_URL}/accounts`)
@@ -15,20 +16,31 @@ function AddTransaction() {
       .then((data) => {
         setAccounts(data);
         setAccountsLoaded(true);
+      })
+      .catch(() => {
+        setLoadError(true);
+        setAccountsLoaded(true);
       });
   }, []);
 
-  const noAccounts = accountsLoaded && accounts.length === 0;
+  const noAccounts = accountsLoaded && !loadError && accounts.length === 0;
 
   return (
     <div className="container">
       <h1 className="pageTitle">Add Transaction</h1>
+      {!accountsLoaded && <p>Loading...</p>}
+      {loadError && (
+        <Alert variant="danger">
+          We couldn't load your accounts. Please check your connection and
+          try again.
+        </Alert>
+      )}
       {noAccounts && (
         <Alert variant="warning">
           Add a bank account first to add a transaction.
         </Alert>
       )}
-      {accountsLoaded && !noAccounts && (
+      {accountsLoaded && !loadError && !noAccounts && (
         <AddTransactionForm accounts={accounts} />
       )}
     </div>

--- a/fm-ui/src/pages/AddTransaction.jsx
+++ b/fm-ui/src/pages/AddTransaction.jsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { Alert } from "react-bootstrap";
+import "../App.css";
+import "bootstrap/dist/css/bootstrap.min.css";
+import { BACKEND_URL } from "../config";
+import AddTransactionForm from "../components/AddTransactionForm";
+
+function AddTransaction() {
+  const [accounts, setAccounts] = useState([]);
+  const [accountsLoaded, setAccountsLoaded] = useState(false);
+
+  useEffect(() => {
+    fetch(`${BACKEND_URL}/accounts`)
+      .then((response) => response.json())
+      .then((data) => {
+        setAccounts(data);
+        setAccountsLoaded(true);
+      });
+  }, []);
+
+  const noAccounts = accountsLoaded && accounts.length === 0;
+
+  return (
+    <div className="container">
+      <h1 className="pageTitle">Add Transaction</h1>
+      {noAccounts && (
+        <Alert variant="warning">
+          Add a bank account first to add a transaction.
+        </Alert>
+      )}
+      {accountsLoaded && !noAccounts && (
+        <AddTransactionForm accounts={accounts} />
+      )}
+    </div>
+  );
+}
+
+export default AddTransaction;

--- a/fm-ui/src/pages/AddTransaction.test.jsx
+++ b/fm-ui/src/pages/AddTransaction.test.jsx
@@ -45,6 +45,60 @@ test("renders the add-transaction form when accounts exist", async () => {
   );
 });
 
+test("shows a loading indicator while GET /accounts is in flight", () => {
+  let resolveFetch;
+  global.fetch = jest.fn(
+    () =>
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+  );
+
+  render(
+    <MemoryRouter>
+      <AddTransaction />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText("Loading...")).toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Add transaction" })
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByText("Add a bank account first to add a transaction.")
+  ).not.toBeInTheDocument();
+
+  // Avoid an unresolved-promise/act warning leaking into other tests.
+  resolveFetch(jsonResponse(200, []));
+});
+
+test("GET /accounts rejecting shows a distinct load-failure message, not a permanently blank page", async () => {
+  global.fetch = jest.fn(() => Promise.reject(new Error("network down")));
+
+  render(
+    <MemoryRouter>
+      <AddTransaction />
+    </MemoryRouter>
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByText(
+        "We couldn't load your accounts. Please check your connection and try again."
+      )
+    ).toBeInTheDocument()
+  );
+
+  // Must be distinguishable from the "zero accounts" empty state and must
+  // not silently render the form.
+  expect(
+    screen.queryByText("Add a bank account first to add a transaction.")
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Add transaction" })
+  ).not.toBeInTheDocument();
+});
+
 test("direct navigation to /addTransaction with zero accounts shows the explanatory message and no submittable form", async () => {
   mockAccountsAndSegments([]);
 

--- a/fm-ui/src/pages/AddTransaction.test.jsx
+++ b/fm-ui/src/pages/AddTransaction.test.jsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import AddTransaction from "./AddTransaction";
+
+function jsonResponse(status, body) {
+  return Promise.resolve({
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body),
+  });
+}
+
+function mockAccountsAndSegments(accounts) {
+  global.fetch = jest.fn((url) => {
+    if (url.endsWith("/accounts")) {
+      return jsonResponse(200, accounts);
+    }
+    if (url.endsWith("/segments")) {
+      return jsonResponse(200, []);
+    }
+    return jsonResponse(200, []);
+  });
+}
+
+test("renders the add-transaction form when accounts exist", async () => {
+  mockAccountsAndSegments([{ id: 1, name: "Current Account" }]);
+
+  render(
+    <MemoryRouter>
+      <AddTransaction />
+    </MemoryRouter>
+  );
+
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: "Add transaction" })).toBeInTheDocument()
+  );
+  expect(
+    screen.queryByText("Add a bank account first to add a transaction.")
+  ).not.toBeInTheDocument();
+
+  // Wait for the form's own segments fetch to settle too, so this test
+  // doesn't finish while that state update is still in flight.
+  await waitFor(() =>
+    expect(screen.getByRole("option", { name: "No segment" })).toBeInTheDocument()
+  );
+});
+
+test("direct navigation to /addTransaction with zero accounts shows the explanatory message and no submittable form", async () => {
+  mockAccountsAndSegments([]);
+
+  render(
+    <MemoryRouter initialEntries={["/addTransaction"]}>
+      <AddTransaction />
+    </MemoryRouter>
+  );
+
+  await waitFor(() =>
+    expect(
+      screen.getByText("Add a bank account first to add a transaction.")
+    ).toBeInTheDocument()
+  );
+  expect(
+    screen.queryByRole("button", { name: "Add transaction" })
+  ).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary

Adds a way to manually add a single transaction, for users who don't want to go through the CSV upload flow. Backend: corrects the pre-existing, incomplete `POST /transactions/transaction` endpoint (it did not work end-to-end before this ticket). Frontend: new `/addTransaction` page, entry point in the Navbar, success/error views.

## Key decisions (approved at Three Amigos, restated here for review-time context)

1. **`Transaction.fileUpload` FK made nullable — real DDL change.** The existing endpoint left `fileUpload` unset, which would have thrown a NOT NULL constraint violation on save. `@JoinColumn(nullable = false)` -> `nullable = true`, applied via `ddl-auto: update`. CSV-imported transactions are unaffected — `CSVHelper` still always assigns a `FileUpload`.
   - **Action required for anyone with an existing local dev DB (including the project lead):** `ddl-auto: update` does **not** retroactively drop a `NOT NULL` constraint on Postgres once it already exists in a live schema — confirmed by direct DB testing during review. Before pulling this branch onto a DB created before this change, run:
     ```sql
     ALTER TABLE transaction ALTER COLUMN file_upload_id DROP NOT NULL;
     ```
     Without this, manual transaction saves will fail with a 500 (constraint violation), even though the code is correct — a fresh/new DB doesn't need this step, only a pre-existing one.

2. **Date handling fixed, not preserved.** The old request took `date` as a `String` parsed via `Transaction`'s CSV-only `transformStringToDate` (`d/M/yyyy`). A native `<input type="date">` produces ISO `yyyy-MM-dd`, which that parser can't handle — this was a real feasibility bug, not a style preference. Fixed by changing `NewTransactionRequest.date` to `LocalDate` (Jackson's `jsr310` module handles ISO parsing natively) and adding a matching `Transaction(LocalDate, ...)` constructor for the manual path. Doesn't touch `CSVHelper` or the CSV column format. Specifically covered end-to-end (not just at the service layer) by a new MockMvc controller test that posts real JSON and asserts the real ISO round-trip — this is the one place a regression here would actually surface.

3. **`accountId` looked up server-side, not trusted from the client.** The old shape accepted a full client-supplied `BankAccount` object and would have persisted it as-is. Now the service looks up the real, managed `BankAccount` by id via `AccountRepository` and 400s if it doesn't exist. `accountId` is `Integer` (not `int`) so a missing key in the JSON deserializes to `null` rather than silently defaulting to `0` — this was caught and fixed during the critique loop (see below).

4. **Money in/out is a pure UI toggle.** No new backend field/column. The frontend's amount input takes a positive magnitude only; the toggle determines the sign applied before the payload is sent. The backend just persists whatever signed `BigDecimal` it receives — no direction concept server-side.

5. **"Segment" dropdown writes into `Transaction.category`, not `Transaction.segment`.** `Transaction.segment` stays at its default `"Undefined"` for manually-added transactions — this was a project-lead-approved tradeoff at the Amigos stage, not an oversight. Worth restating plainly because of its effect on existing UI: the existing transaction list (`Transaction.jsx`) renders `category` in its "Category" column, so manually-added transactions will show their chosen segment name there.

6. **No-accounts state is enforced twice, independently.** The Navbar fetches `GET /accounts` itself (previously fetched nothing) to show the "Add Transaction" entry visible-but-disabled with explanatory text when there are zero accounts. The `/addTransaction` page independently re-checks the same condition, so direct/bookmarked navigation while there are zero accounts can't bypass the nav-level gate.

7. **Success/error views are in-page state swaps (`form` <-> `success`/`error`), not separate routes** — matches the existing app pattern (e.g. `UploadFile.jsx`'s inline alert swap) rather than introducing a new routing pattern for one feature.

## What the critique loop caught before this reached QA (worth naming, not just "reviewed, no issues")

- A fragile `int` vs `Integer` `accountId` bug (missing key defaulted to `0` instead of surfacing as "missing").
- Dead code: an old unused `TransactionService.addTransaction(Transaction)` overload with zero remaining callers, removed.
- Three accessibility gaps: the money-in/out radio group wasn't programmatically associated as a labeled fieldset; the disabled Navbar entry didn't announce its disabled state to assistive tech (and stayed in the tab order); a rejected `GET /accounts` fetch silently left the Add Transaction page blank with no explanation.

## What was tested and how

**Backend** — 22 tests, all passing (`mvn test`, independently re-run for this sign-off):
- `TransactionServiceTest` (13 tests): full AC checklist — valid payload, each required-field violation individually, zero amount, future date, unknown `accountId`, segment/category mapping both directions, optional memo, negative amount accepted as-is.
- `TransactionPersistenceTest` (`@DataJpaTest`, H2, 2 tests): the DDL change verified at the DB level — a manual transaction with `fileUpload = null` persists/retrieves cleanly, and a CSV-style transaction still requires and correctly links a non-null `FileUpload`.
- `TransactionControllerTest` (`@WebMvcTest`, MockMvc, 3 tests): added specifically to close a QA-identified gap — the service-layer tests never exercised real Jackson (de)serialization or the real HTTP response shape. This is the only test that would actually catch a regression in ISO-date round-tripping (the ticket's original core defect) or in the missing-`accountId`-key-deserializes-to-null behavior.
- All 11 backend AC checklist items map to an asserting test.

**Frontend** — 18/19 tests passing (`npm test`, independently re-run):
- Covers dropdown population from `GET /accounts`/`GET /segments`, per-field inline validation (each required field individually, matching the FM-65 pattern), the money in/out sign toggle, zero/negative/future-date blocking, the success view and both its actions, the backend-400/network-failure error view (distinct from inline validation), nav- and page-level no-accounts gating, and duplicate-submission (allowed, no dedup, matching existing CSV-import behavior).
- The 1 failing test (`App.test.js`) is a pre-existing, unrelated failure (`useRoutes() may be used only in the context of a <Router> component`) that predates this branch — confirmed the file is untouched by any commit on this branch.
- All 10 frontend AC checklist items map to an asserting test.

QA independently re-ran both suites and mapped every AC checklist item to a specific test before signing off.

## Flagged / deferred (not fixed here, called out per CLAUDE.md guardrails)

- **DDL manual step above** — required for anyone with a pre-existing local dev DB; not automatic.
- **Category/segment display consequence above** — deliberate tradeoff, not a defect, but affects how existing UI displays these rows.
- **`fm-backend/target/` (Maven build output) is tracked in git.** Predates this ticket entirely — confirmed present on `main` before this branch existed. Not touched or fixed here; worth a separate cleanup ticket (add to `.gitignore`, `git rm -r --cached`).

## Sign-off

Confirmed against the original ticket intent, not just literal AC compliance: a user can now add a single transaction without a CSV, all seven fields are present and correctly validated both client- and server-side, dropdowns are populated from existing data, the success view shows the persisted (backend-authoritative) record with both required actions, the no-accounts case is properly gated at two independent points, and save failures route to a dedicated error view distinct from field-level validation. No drift found between what was asked and what was built.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>