### PR TITLE
[FM-52] Filter transactions by date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.csv
 ./test-data
+TICKET.md

--- a/fm-backend/src/main/java/com/controller/AccountController.java
+++ b/fm-backend/src/main/java/com/controller/AccountController.java
@@ -5,11 +5,13 @@ import com.dto.request.NewBankAccountRequest;
 import com.service.AccountService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.FileNotFoundException;
+import java.time.LocalDate;
 import java.util.Currency;
 import java.util.EnumSet;
 import java.util.List;
@@ -52,12 +54,25 @@ public class AccountController {
         return new ResponseEntity<>(Currency.getAvailableCurrencies(), HttpStatus.OK);
     }
 
+    // FM-52: startDate/endDate are optional, ISO yyyy-MM-dd (bound via Spring's default LocalDate
+    // conversion, same format the manual-add-transaction JSON path already uses). All range
+    // validation (both-required, start-after-end, future-date) lives in AccountService per the
+    // existing controller-thin/service-holds-logic convention - the controller only translates the
+    // service's IllegalArgumentException into a 400, matching TransactionController's pattern for
+    // addTransaction/updateTransactionSegment.
     @GetMapping("/account/{id}/transactions")
-    public Page<Transaction> getAccountTransactions(
+    public ResponseEntity<?> getAccountTransactions(
             @PathVariable("id") int id,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
-        return accountService.getPaginatedAccountTransactions(id, page, size);
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        try {
+            Page<Transaction> transactions = accountService.getPaginatedAccountTransactions(id, page, size, startDate, endDate);
+            return new ResponseEntity<>(transactions, HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
     }
 
     @GetMapping("/account/{id}/transactions/monthly")

--- a/fm-backend/src/main/java/com/repository/TransactionRepository.java
+++ b/fm-backend/src/main/java/com/repository/TransactionRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
@@ -21,6 +22,16 @@ public interface TransactionRepository extends JpaRepository<Transaction, Intege
 
     @Query(value = "SELECT * FROM transaction WHERE account_id=?1", countQuery = "SELECT COUNT(*) FROM transaction WHERE account_id=?1", nativeQuery = true)
     Page<Transaction> findAllByAccount_IdWithPagination(int id, Pageable pageable);
+
+    // FM-52: AC-8 - the date-range WHERE clause is deliberately duplicated identically on both the
+    // row-fetching query and the countQuery. Spring Data's native countQuery is a completely
+    // separate, hand-written string (not derived from the main query), so if this filter were only
+    // added to one of them, totalElements/totalPages would silently reflect the wrong (unfiltered)
+    // total once a date filter actually narrows the result set. Both bounds are inclusive (AC-6/AC-7).
+    @Query(value = "SELECT * FROM transaction WHERE account_id=?1 AND date >= ?2 AND date <= ?3",
+            countQuery = "SELECT COUNT(*) FROM transaction WHERE account_id=?1 AND date >= ?2 AND date <= ?3",
+            nativeQuery = true)
+    Page<Transaction> findAllByAccount_IdAndDateBetweenWithPagination(int id, LocalDate startDate, LocalDate endDate, Pageable pageable);
 
     @Query(value = "SELECT * FROM transaction WHERE account_id=?1 AND EXTRACT('month' from date) = ?2 AND EXTRACT('year' from date) = ?3", nativeQuery = true)
     List<Transaction> findAllByAccount_IdAndDateInMonthYear(int id, int month, int year);

--- a/fm-backend/src/main/java/com/service/AccountService.java
+++ b/fm-backend/src/main/java/com/service/AccountService.java
@@ -76,8 +76,35 @@ public class AccountService {
         accountRepository.deleteById(id);
     }
 
-    public Page<Transaction> getPaginatedAccountTransactions(int id, int page, int size) {
+    // FM-52: startDate/endDate are optional and, when both supplied, form an inclusive range.
+    // AC-2 requires the no-filter path to stay byte-for-byte unchanged, so the original
+    // unfiltered/paginated query is only used when neither date is supplied; the new date-range
+    // query (with an identical WHERE clause on its native countQuery, per AC-8) is used otherwise.
+    public Page<Transaction> getPaginatedAccountTransactions(int id, int page, int size, LocalDate startDate, LocalDate endDate) {
+        validateDateRange(startDate, endDate);
         Pageable pageable = PageRequest.of(page, size);
-        return transactionRepository.findAllByAccount_IdWithPagination(id, pageable);
+        if (startDate == null && endDate == null) {
+            return transactionRepository.findAllByAccount_IdWithPagination(id, pageable);
+        }
+        return transactionRepository.findAllByAccount_IdAndDateBetweenWithPagination(id, startDate, endDate, pageable);
+    }
+
+    // FM-52: AC-3/AC-4/AC-5. Order follows the acceptance criteria as written: reject a lone
+    // param first, then an inverted range, then a future date. endDate == today is valid
+    // (inclusive), matching the existing future-date check in
+    // TransactionService.addManualTransaction, which rejects only isAfter(LocalDate.now()).
+    private void validateDateRange(LocalDate startDate, LocalDate endDate) {
+        if ((startDate == null) != (endDate == null)) {
+            throw new IllegalArgumentException("Both start date and end date are required");
+        }
+        if (startDate == null) {
+            return;
+        }
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalArgumentException("Start date cannot be after end date");
+        }
+        if (startDate.isAfter(LocalDate.now()) || endDate.isAfter(LocalDate.now())) {
+            throw new IllegalArgumentException("Date cannot be in the future");
+        }
     }
 }

--- a/fm-backend/src/test/java/com/controller/AccountControllerTest.java
+++ b/fm-backend/src/test/java/com/controller/AccountControllerTest.java
@@ -1,0 +1,115 @@
+package com.controller;
+
+import com.dto.Transaction;
+import com.service.AccountService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// FM-52: HTTP-level coverage for GET /accounts/account/{id}/transactions - complements the
+// Mockito-based AccountServiceTest (business rules) by proving the controller actually parses the
+// ISO "yyyy-MM-dd" query params into real LocalDates before calling the service (AC-1), leaves the
+// existing page/size params and success response shape alone when no dates are supplied (AC-2),
+// and translates the service's validation IllegalArgumentException into a real 400 with the
+// exception's message as a plain-text body (AC-3/AC-4/AC-5), matching TransactionController's
+// existing addTransaction/updateTransactionSegment pattern.
+@WebMvcTest(AccountController.class)
+class AccountControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AccountService accountService;
+
+    // AC-2: no startDate/endDate supplied -> service is called with null dates, same page/size
+    // handling as before, 200 with the page body.
+    @Test
+    void noDateParamsSuppliedCallsServiceWithNullDatesAndReturns200() throws Exception {
+        Page<Transaction> stubbedPage = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+        when(accountService.getPaginatedAccountTransactions(eq(1), eq(0), eq(10), isNull(), isNull()))
+                .thenReturn(stubbedPage);
+
+        mockMvc.perform(get("/accounts/account/1/transactions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(0));
+
+        verify(accountService).getPaginatedAccountTransactions(1, 0, 10, null, null);
+    }
+
+    // AC-1: startDate/endDate query params (ISO yyyy-MM-dd) are parsed into real LocalDates and
+    // passed through to the service.
+    @Test
+    void dateParamsAreParsedFromIsoStringsAndPassedToTheService() throws Exception {
+        Page<Transaction> stubbedPage = new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+        when(accountService.getPaginatedAccountTransactions(
+                eq(1), eq(0), eq(10), eq(LocalDate.of(2024, 1, 1)), eq(LocalDate.of(2024, 1, 31))))
+                .thenReturn(stubbedPage);
+
+        mockMvc.perform(get("/accounts/account/1/transactions")
+                        .param("startDate", "2024-01-01")
+                        .param("endDate", "2024-01-31"))
+                .andExpect(status().isOk());
+
+        verify(accountService).getPaginatedAccountTransactions(
+                1, 0, 10, LocalDate.of(2024, 1, 1), LocalDate.of(2024, 1, 31));
+    }
+
+    // AC-3: service rejection for a lone date param must surface as a real 400 with the
+    // exception's message as the body.
+    @Test
+    void serviceRejectionForALoneDateParamReturns400WithMessageBody() throws Exception {
+        when(accountService.getPaginatedAccountTransactions(eq(1), eq(0), eq(10), eq(LocalDate.of(2024, 1, 1)), isNull()))
+                .thenThrow(new IllegalArgumentException("Both start date and end date are required"));
+
+        mockMvc.perform(get("/accounts/account/1/transactions")
+                        .param("startDate", "2024-01-01"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Both start date and end date are required"));
+    }
+
+    // AC-4: an inverted range surfaces the service's specific message via 400.
+    @Test
+    void serviceRejectionForAnInvertedRangeReturns400WithMessageBody() throws Exception {
+        when(accountService.getPaginatedAccountTransactions(
+                eq(1), eq(0), eq(10), eq(LocalDate.of(2024, 1, 31)), eq(LocalDate.of(2024, 1, 1))))
+                .thenThrow(new IllegalArgumentException("Start date cannot be after end date"));
+
+        mockMvc.perform(get("/accounts/account/1/transactions")
+                        .param("startDate", "2024-01-31")
+                        .param("endDate", "2024-01-01"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Start date cannot be after end date"));
+    }
+
+    // AC-5: a future date surfaces the service's specific message via 400.
+    @Test
+    void serviceRejectionForAFutureDateReturns400WithMessageBody() throws Exception {
+        LocalDate future = LocalDate.now().plusDays(1);
+        when(accountService.getPaginatedAccountTransactions(eq(1), eq(0), eq(10), eq(future), eq(future)))
+                .thenThrow(new IllegalArgumentException("Date cannot be in the future"));
+
+        mockMvc.perform(get("/accounts/account/1/transactions")
+                        .param("startDate", future.toString())
+                        .param("endDate", future.toString()))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("Date cannot be in the future"));
+    }
+}

--- a/fm-backend/src/test/java/com/repository/TransactionDateRangePaginationRepositoryTest.java
+++ b/fm-backend/src/test/java/com/repository/TransactionDateRangePaginationRepositoryTest.java
@@ -1,0 +1,123 @@
+package com.repository;
+
+import com.dto.BankAccount;
+import com.dto.Transaction;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// FM-52: real-database (H2) coverage for TransactionRepository.findAllByAccount_IdAndDateBetweenWithPagination.
+// AC-8 is the important case here - this repository method's countQuery is a completely separate,
+// hand-written native SQL string from its row-fetching query (Spring Data does not derive one from
+// the other for native queries), so a bug where the WHERE clause was added to only one of them
+// would still return the right page of rows but silently wrong totalElements/totalPages. A
+// Mockito-based test (AccountServiceTest) can never catch that, since it stubs the whole Page
+// return value - only a real Pageable/Page round trip against a real query can.
+@DataJpaTest
+class TransactionDateRangePaginationRepositoryTest {
+
+    @Autowired
+    private TransactionRepository transactionRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    private BankAccount newAccount(String sortCode, String accountNumber) {
+        return accountRepository.save(
+                new BankAccount("Account " + sortCode, sortCode, accountNumber, new BigDecimal(2000), LocalDate.now()));
+    }
+
+    private Transaction newTransaction(BankAccount account, LocalDate date) {
+        return transactionRepository.save(
+                new Transaction(date, account, BigDecimal.TEN, null, "Tesco", "Weekly shop"));
+    }
+
+    // AC-8: seed an account with transactions spanning multiple pages (5 total, page size 2 ->
+    // 3 unfiltered pages), where only a subset (2 of the 5) falls inside the filtered date range.
+    // totalElements/totalPages must reflect the filtered subset (2 elements, 1 page at size 2),
+    // not the account's full unfiltered total (5 elements, 3 pages).
+    @Test
+    void pagesAndCountsReflectOnlyTheFilteredSubsetNotTheAccountsFullTotal() {
+        BankAccount account = newAccount("SORTCODE20", "ACCNUMBER20");
+
+        // Outside the filtered range (before it).
+        newTransaction(account, LocalDate.of(2024, 1, 1));
+        newTransaction(account, LocalDate.of(2024, 1, 5));
+        // Inside the filtered range [2024-01-10, 2024-01-20].
+        newTransaction(account, LocalDate.of(2024, 1, 10));
+        newTransaction(account, LocalDate.of(2024, 1, 15));
+        // Outside the filtered range (after it).
+        newTransaction(account, LocalDate.of(2024, 1, 25));
+
+        Page<Transaction> unfilteredFirstPage = transactionRepository.findAllByAccount_IdWithPagination(
+                account.getId(), PageRequest.of(0, 2));
+        assertEquals(5, unfilteredFirstPage.getTotalElements());
+        assertEquals(3, unfilteredFirstPage.getTotalPages());
+
+        Page<Transaction> filteredFirstPage = transactionRepository.findAllByAccount_IdAndDateBetweenWithPagination(
+                account.getId(), LocalDate.of(2024, 1, 10), LocalDate.of(2024, 1, 20), PageRequest.of(0, 2));
+
+        assertEquals(2, filteredFirstPage.getTotalElements());
+        assertEquals(1, filteredFirstPage.getTotalPages());
+        assertEquals(2, filteredFirstPage.getContent().size());
+        assertTrue(filteredFirstPage.getContent().stream()
+                .allMatch(t -> !t.getDate().isBefore(LocalDate.of(2024, 1, 10))
+                        && !t.getDate().isAfter(LocalDate.of(2024, 1, 20))));
+    }
+
+    // AC-7: the range is inclusive on both ends - transactions dated exactly startDate or
+    // exactly endDate must be included, not just strictly-between dates.
+    @Test
+    void rangeIsInclusiveOfBothTheStartDateAndTheEndDate() {
+        BankAccount account = newAccount("SORTCODE21", "ACCNUMBER21");
+        Transaction onStartDate = newTransaction(account, LocalDate.of(2024, 2, 1));
+        Transaction onEndDate = newTransaction(account, LocalDate.of(2024, 2, 10));
+        newTransaction(account, LocalDate.of(2024, 2, 11)); // just outside the range
+
+        Page<Transaction> result = transactionRepository.findAllByAccount_IdAndDateBetweenWithPagination(
+                account.getId(), LocalDate.of(2024, 2, 1), LocalDate.of(2024, 2, 10), PageRequest.of(0, 10));
+
+        assertEquals(2, result.getTotalElements());
+        assertTrue(result.getContent().stream().anyMatch(t -> t.getId() == onStartDate.getId()));
+        assertTrue(result.getContent().stream().anyMatch(t -> t.getId() == onEndDate.getId()));
+    }
+
+    // AC-6: startDate == endDate (single-day range) returns exactly the transactions on that
+    // exact date.
+    @Test
+    void singleDayRangeReturnsOnlyTransactionsOnThatExactDate() {
+        BankAccount account = newAccount("SORTCODE22", "ACCNUMBER22");
+        newTransaction(account, LocalDate.of(2024, 3, 4));
+        newTransaction(account, LocalDate.of(2024, 3, 5));
+        newTransaction(account, LocalDate.of(2024, 3, 6));
+
+        Page<Transaction> result = transactionRepository.findAllByAccount_IdAndDateBetweenWithPagination(
+                account.getId(), LocalDate.of(2024, 3, 5), LocalDate.of(2024, 3, 5), PageRequest.of(0, 10));
+
+        assertEquals(1, result.getTotalElements());
+        assertEquals(LocalDate.of(2024, 3, 5), result.getContent().get(0).getDate());
+    }
+
+    // AC-9: a valid range with zero matching transactions is not an error - just an empty page
+    // with totalElements 0.
+    @Test
+    void validRangeWithNoMatchingTransactionsReturnsAnEmptyPageNotAnError() {
+        BankAccount account = newAccount("SORTCODE23", "ACCNUMBER23");
+        newTransaction(account, LocalDate.of(2024, 4, 1));
+
+        Page<Transaction> result = transactionRepository.findAllByAccount_IdAndDateBetweenWithPagination(
+                account.getId(), LocalDate.of(2024, 5, 1), LocalDate.of(2024, 5, 31), PageRequest.of(0, 10));
+
+        assertEquals(0, result.getTotalElements());
+        assertEquals(0, result.getTotalPages());
+        assertTrue(result.getContent().isEmpty());
+    }
+}

--- a/fm-backend/src/test/java/com/service/AccountServiceTest.java
+++ b/fm-backend/src/test/java/com/service/AccountServiceTest.java
@@ -1,6 +1,7 @@
 package com.service;
 
 import com.dto.BankAccount;
+import com.dto.Transaction;
 import com.repository.AccountRepository;
 import com.repository.TransactionRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,13 +11,23 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.io.FileNotFoundException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 // Note: this test previously called `new AccountService(accountRepository, transactionRepository,
@@ -73,6 +84,127 @@ public class AccountServiceTest {
         String actualMessage = exception.getMessage();
 
         assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    // ---- FM-52: getPaginatedAccountTransactions date-range filtering ----
+
+    // AC-2: with neither date supplied, the original unfiltered/paginated repository method must
+    // still be the one invoked (not the new date-range query), so today's behavior stays
+    // byte-for-byte unchanged.
+    @Test
+    public void usesTheUnfilteredQueryWhenNeitherDateIsSupplied() {
+        Page<Transaction> stubbedPage = new PageImpl<>(List.of());
+        when(transactionRepository.findAllByAccount_IdWithPagination(eq(1), any(Pageable.class)))
+                .thenReturn(stubbedPage);
+
+        Page<Transaction> result = service.getPaginatedAccountTransactions(1, 0, 10, null, null);
+
+        assertEquals(stubbedPage, result);
+        verify(transactionRepository).findAllByAccount_IdWithPagination(1, PageRequest.of(0, 10));
+        verify(transactionRepository, never())
+                .findAllByAccount_IdAndDateBetweenWithPagination(anyInt(), any(), any(), any());
+    }
+
+    // AC-1/AC-7: with both dates supplied, the date-range query must be used, with both bounds
+    // passed through unchanged (inclusive range, no swapping).
+    @Test
+    public void usesTheDateRangeQueryWhenBothDatesAreSupplied() {
+        LocalDate startDate = LocalDate.of(2024, 1, 1);
+        LocalDate endDate = LocalDate.of(2024, 1, 31);
+        Page<Transaction> stubbedPage = new PageImpl<>(List.of());
+        when(transactionRepository.findAllByAccount_IdAndDateBetweenWithPagination(
+                eq(1), eq(startDate), eq(endDate), any(Pageable.class)))
+                .thenReturn(stubbedPage);
+
+        Page<Transaction> result = service.getPaginatedAccountTransactions(1, 0, 10, startDate, endDate);
+
+        assertEquals(stubbedPage, result);
+        verify(transactionRepository)
+                .findAllByAccount_IdAndDateBetweenWithPagination(1, startDate, endDate, PageRequest.of(0, 10));
+        verify(transactionRepository, never()).findAllByAccount_IdWithPagination(anyInt(), any());
+    }
+
+    // AC-6: startDate == endDate is a valid single-day range, not an error.
+    @Test
+    public void allowsAndFiltersOnASingleDayRange() {
+        LocalDate sameDay = LocalDate.now().minusDays(1);
+        Page<Transaction> stubbedPage = new PageImpl<>(List.of());
+        when(transactionRepository.findAllByAccount_IdAndDateBetweenWithPagination(
+                eq(1), eq(sameDay), eq(sameDay), any(Pageable.class)))
+                .thenReturn(stubbedPage);
+
+        Page<Transaction> result = service.getPaginatedAccountTransactions(1, 0, 10, sameDay, sameDay);
+
+        assertEquals(stubbedPage, result);
+    }
+
+    // AC-3: exactly one of the two params supplied must be rejected, not treated as an
+    // open-ended filter, regardless of which one is missing.
+    @Test
+    public void rejectsWhenOnlyStartDateIsSupplied() {
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> service.getPaginatedAccountTransactions(1, 0, 10, LocalDate.now(), null));
+
+        assertEquals("Both start date and end date are required", exception.getMessage());
+    }
+
+    @Test
+    public void rejectsWhenOnlyEndDateIsSupplied() {
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> service.getPaginatedAccountTransactions(1, 0, 10, null, LocalDate.now()));
+
+        assertEquals("Both start date and end date are required", exception.getMessage());
+    }
+
+    // AC-4: an inverted range is rejected outright, never silently swapped.
+    @Test
+    public void rejectsWhenStartDateIsAfterEndDate() {
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = LocalDate.now().minusDays(1);
+
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> service.getPaginatedAccountTransactions(1, 0, 10, startDate, endDate));
+
+        assertEquals("Start date cannot be after end date", exception.getMessage());
+    }
+
+    // AC-5: strictly-in-the-future dates are rejected...
+    @Test
+    public void rejectsWhenStartDateIsInTheFuture() {
+        LocalDate startDate = LocalDate.now().plusDays(1);
+        LocalDate endDate = LocalDate.now().plusDays(2);
+
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> service.getPaginatedAccountTransactions(1, 0, 10, startDate, endDate));
+
+        assertEquals("Date cannot be in the future", exception.getMessage());
+    }
+
+    @Test
+    public void rejectsWhenEndDateIsInTheFuture() {
+        LocalDate startDate = LocalDate.now();
+        LocalDate endDate = LocalDate.now().plusDays(1);
+
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> service.getPaginatedAccountTransactions(1, 0, 10, startDate, endDate));
+
+        assertEquals("Date cannot be in the future", exception.getMessage());
+    }
+
+    // ...but endDate == today is inclusive/valid, matching
+    // TransactionService.addManualTransaction's isAfter(LocalDate.now()) pattern.
+    @Test
+    public void allowsEndDateEqualToToday() {
+        LocalDate startDate = LocalDate.now().minusDays(5);
+        LocalDate endDate = LocalDate.now();
+        Page<Transaction> stubbedPage = new PageImpl<>(List.of());
+        when(transactionRepository.findAllByAccount_IdAndDateBetweenWithPagination(
+                eq(1), eq(startDate), eq(endDate), any(Pageable.class)))
+                .thenReturn(stubbedPage);
+
+        Page<Transaction> result = service.getPaginatedAccountTransactions(1, 0, 10, startDate, endDate);
+
+        assertEquals(stubbedPage, result);
     }
 
 }

--- a/fm-ui/src/components/TransactionContainer.jsx
+++ b/fm-ui/src/components/TransactionContainer.jsx
@@ -43,7 +43,34 @@ const TransactionContainer = ({ id }) => {
       const response = await fetch(
         `${BACKEND_URL}/accounts/account/${id}/transactions?${params.toString()}`
       );
+      if (!response.ok) {
+        // Bug fix: AccountController/AccountService return a plain-text body
+        // on rejection (e.g. "Date cannot be in the future"), not JSON -
+        // calling response.json() on that would throw and get swallowed by
+        // the generic catch below, leaving stale pre-filter items on screen
+        // looking like a valid filtered result. Only surface this for a
+        // filtered request - the unfiltered load has no error UI in scope
+        // here, matching the filterLoading gating above.
+        if (filtering) {
+          let message = "Failed to load filtered transactions. Please try again.";
+          try {
+            const text = await response.text();
+            if (text) {
+              message = text;
+            }
+          } catch (readError) {
+            // Body couldn't be read - fall back to the generic message above.
+          }
+          setFilterError(message);
+          setItems([]);
+          setTotalPages(0);
+        }
+        return;
+      }
       const data = await response.json();
+      if (filtering) {
+        setFilterError("");
+      }
       setItems(data.content);
       setTotalPages(data.totalPages);
     } catch (error) {
@@ -168,7 +195,7 @@ const TransactionContainer = ({ id }) => {
         </div>
       )}
 
-      {isFiltered && !filterLoading && items.length === 0 ? (
+      {isFiltered && !filterLoading && !filterError && items.length === 0 ? (
         <p>No transactions in this date range</p>
       ) : (
         <TransactionTable items={items} />

--- a/fm-ui/src/components/TransactionContainer.jsx
+++ b/fm-ui/src/components/TransactionContainer.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from "react";
 import { BACKEND_URL } from "../config";
-import { Pagination } from "react-bootstrap";
+import { Pagination, Form, Button, Row, Col, Spinner } from "react-bootstrap";
 import TransactionTable from "./TransactionTable";
+import { getTodayIsoDate } from "../helpers/utils";
 
 const TransactionContainer = ({ id }) => {
   const [items, setItems] = useState([]);
@@ -9,30 +10,170 @@ const TransactionContainer = ({ id }) => {
   const [totalPages, setTotalPages] = useState(0);
   const itemsPerPage = 10;
 
-  const fetchItems = async (page) => {
+  // FM-52 AC-12: "input" state (what's currently typed/picked in the date
+  // fields) is tracked separately from "applied" state (what was last
+  // actually sent to the backend). Only Apply moves input -> applied, so
+  // typing/picking a date alone never triggers a refetch.
+  const [startDateInput, setStartDateInput] = useState("");
+  const [endDateInput, setEndDateInput] = useState("");
+  const [appliedStartDate, setAppliedStartDate] = useState(null);
+  const [appliedEndDate, setAppliedEndDate] = useState(null);
+  const [filterError, setFilterError] = useState("");
+  const [filterLoading, setFilterLoading] = useState(false);
+
+  // Both are always set/cleared together (see handleApply/handleClear), so
+  // checking either is sufficient - kept as a single derived flag so the
+  // "filtered vs unfiltered" question is asked in one place.
+  const isFiltered = Boolean(appliedStartDate && appliedEndDate);
+
+  const fetchItems = async (page, startDate, endDate) => {
+    const filtering = Boolean(startDate && endDate);
+    // AC-17: minimal loading indicator specifically for a filtered fetch in
+    // flight - the pre-existing unfiltered load has no such indicator and
+    // this ticket doesn't add general loading/error handling to it.
+    if (filtering) {
+      setFilterLoading(true);
+    }
     try {
+      const params = new URLSearchParams({ page, size: itemsPerPage });
+      if (filtering) {
+        params.set("startDate", startDate);
+        params.set("endDate", endDate);
+      }
       const response = await fetch(
-        `${BACKEND_URL}/accounts/account/${id}/transactions?page=${page}&limit=${itemsPerPage}`
+        `${BACKEND_URL}/accounts/account/${id}/transactions?${params.toString()}`
       );
       const data = await response.json();
       setItems(data.content);
       setTotalPages(data.totalPages);
     } catch (error) {
       console.error("Error fetching items:", error);
+    } finally {
+      if (filtering) {
+        setFilterLoading(false);
+      }
     }
   };
 
+  // AC-11/AC-19: every fresh mount starts from unfiltered state (nothing is
+  // persisted), so the first fetch here always runs with no dates. AC-20:
+  // paginating while filtered re-fetches with the same applied dates rather
+  // than dropping them, since this effect re-runs on any of these changing.
   useEffect(() => {
-    fetchItems(currentPage);
-  });
+    fetchItems(currentPage, appliedStartDate, appliedEndDate);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, currentPage, appliedStartDate, appliedEndDate]);
 
   const handlePageChange = (page) => {
     setCurrentPage(page);
   };
 
+  // AC-14: mirrors AccountService's backend validation (both required,
+  // start-after-end, no future dates) so an invalid range never reaches the
+  // network. The backend still enforces the same rules independently - this
+  // is a fast-fail UX layer, not a replacement for it.
+  const validationErrorFor = (startDate, endDate) => {
+    const today = getTodayIsoDate();
+    if (startDate > endDate) {
+      return "Start date cannot be after end date";
+    }
+    if (startDate > today || endDate > today) {
+      return "Date cannot be in the future";
+    }
+    return "";
+  };
+
+  const handleApply = () => {
+    // AC-13: Apply is also disabled via the `disabled` prop below when
+    // either field is empty - this is a defensive second check so a
+    // request is never sent with only one date set.
+    if (!startDateInput || !endDateInput) {
+      setFilterError("Both start date and end date are required");
+      return;
+    }
+    const message = validationErrorFor(startDateInput, endDateInput);
+    if (message) {
+      setFilterError(message);
+      return;
+    }
+    setFilterError("");
+    setCurrentPage(0);
+    setAppliedStartDate(startDateInput);
+    setAppliedEndDate(endDateInput);
+  };
+
+  const handleClear = () => {
+    setStartDateInput("");
+    setEndDateInput("");
+    setFilterError("");
+    setCurrentPage(0);
+    setAppliedStartDate(null);
+    setAppliedEndDate(null);
+  };
+
   return (
     <div>
-      <TransactionTable items={items} />
+      <Form className="mb-3">
+        <Row className="align-items-end g-2">
+          <Col xs="auto">
+            <Form.Group controlId="transactionFilterStartDate">
+              <Form.Label>Start date</Form.Label>
+              <Form.Control
+                type="date"
+                value={startDateInput}
+                onChange={(e) => setStartDateInput(e.target.value)}
+              />
+            </Form.Group>
+          </Col>
+          <Col xs="auto">
+            <Form.Group controlId="transactionFilterEndDate">
+              <Form.Label>End date</Form.Label>
+              <Form.Control
+                type="date"
+                value={endDateInput}
+                onChange={(e) => setEndDateInput(e.target.value)}
+              />
+            </Form.Group>
+          </Col>
+          <Col xs="auto">
+            <Button
+              variant="primary"
+              onClick={handleApply}
+              disabled={!startDateInput || !endDateInput}
+            >
+              Apply
+            </Button>
+          </Col>
+          <Col xs="auto">
+            <Button variant="secondary" onClick={handleClear}>
+              Clear
+            </Button>
+          </Col>
+        </Row>
+        {filterError && (
+          <Row className="mt-2">
+            <Col xs="auto">
+              <div className="text-danger" role="alert">
+                {filterError}
+              </div>
+            </Col>
+          </Row>
+        )}
+      </Form>
+
+      {filterLoading && (
+        <div className="mb-2" role="status">
+          <Spinner animation="border" size="sm" /> Loading filtered
+          transactions...
+        </div>
+      )}
+
+      {isFiltered && !filterLoading && items.length === 0 ? (
+        <p>No transactions in this date range</p>
+      ) : (
+        <TransactionTable items={items} />
+      )}
+
       <PaginationObject
         totalPages={totalPages}
         currentPage={currentPage}

--- a/fm-ui/src/components/TransactionContainer.test.jsx
+++ b/fm-ui/src/components/TransactionContainer.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TransactionContainer from "./TransactionContainer";
+import { getTodayIsoDate } from "../helpers/utils";
 
 function page(content, { totalPages = 1 } = {}) {
   return { content, totalPages };
@@ -113,6 +114,23 @@ test("AC-14: start-after-end is blocked client-side with an inline error and no 
     "Start date cannot be after end date"
   );
   expect(transactionCalls()).toHaveLength(1);
+});
+
+test("AC-5/AC-14: an end date of exactly today is inclusive and valid client-side (not treated as future)", async () => {
+  setupFetchMock((url) => jsonResponse(200, page(unfilteredItems)));
+  render(<TransactionContainer id={1} />);
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+
+  const today = getTodayIsoDate();
+  await userEvent.type(screen.getByLabelText("Start date"), "2020-01-01");
+  await userEvent.type(screen.getByLabelText("End date"), today);
+  await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+  // No client-side validation error, and the filtered request actually fires.
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  await waitFor(() => expect(transactionCalls()).toHaveLength(2));
+  const url = lastTransactionCallUrl();
+  expect(url.searchParams.get("endDate")).toBe(today);
 });
 
 test("AC-14: a future date is blocked client-side with an inline error and no network call", async () => {

--- a/fm-ui/src/components/TransactionContainer.test.jsx
+++ b/fm-ui/src/components/TransactionContainer.test.jsx
@@ -1,0 +1,256 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TransactionContainer from "./TransactionContainer";
+
+function page(content, { totalPages = 1 } = {}) {
+  return { content, totalPages };
+}
+
+const unfilteredItems = [
+  {
+    id: 1,
+    date: "2020-01-15",
+    amount: 25.5,
+    category: "Groceries",
+    paid_to: "Tesco",
+    memo: "",
+    segment: "Undefined",
+  },
+];
+
+function jsonResponse(status, body) {
+  return Promise.resolve({
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body),
+    text: () =>
+      Promise.resolve(typeof body === "string" ? body : JSON.stringify(body ?? {})),
+  });
+}
+
+// Segment lookups fired by the nested TransactionTable aren't the concern of
+// these tests - always resolve them to an empty list so they don't interfere.
+function setupFetchMock(handleTransactions) {
+  global.fetch = jest.fn((url) => {
+    if (url.endsWith("/segments")) {
+      return jsonResponse(200, []);
+    }
+    return handleTransactions(url);
+  });
+}
+
+function transactionCalls() {
+  return global.fetch.mock.calls.filter(([url]) => url.includes("/transactions?"));
+}
+
+function lastTransactionCallUrl() {
+  const calls = transactionCalls();
+  return new URL(calls[calls.length - 1][0]);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("AC-11: initial load fetches the unfiltered list at page 0, filter not auto-applied", async () => {
+  setupFetchMock(() => jsonResponse(200, page(unfilteredItems)));
+  render(<TransactionContainer id={1} />);
+
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+  const url = lastTransactionCallUrl();
+  expect(url.searchParams.get("page")).toBe("0");
+  expect(url.searchParams.get("startDate")).toBeNull();
+  expect(url.searchParams.get("endDate")).toBeNull();
+});
+
+test("fixes the pagination param bug: sends `size`, not `limit`", async () => {
+  setupFetchMock(() => jsonResponse(200, page(unfilteredItems)));
+  render(<TransactionContainer id={1} />);
+
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+  const url = lastTransactionCallUrl();
+  expect(url.searchParams.get("size")).toBe("10");
+  expect(url.searchParams.has("limit")).toBe(false);
+});
+
+test("AC-12: typing into the date inputs does not by itself trigger a refetch", async () => {
+  setupFetchMock(() => jsonResponse(200, page(unfilteredItems)));
+  render(<TransactionContainer id={1} />);
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+
+  await userEvent.type(screen.getByLabelText("Start date"), "2020-01-01");
+  await userEvent.type(screen.getByLabelText("End date"), "2020-01-31");
+
+  // Still just the one initial fetch - no request fired from typing alone.
+  expect(transactionCalls()).toHaveLength(1);
+});
+
+test("AC-13: Apply is disabled unless both start and end date are filled in", async () => {
+  setupFetchMock(() => jsonResponse(200, page(unfilteredItems)));
+  render(<TransactionContainer id={1} />);
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+
+  const applyButton = screen.getByRole("button", { name: "Apply" });
+  expect(applyButton).toBeDisabled();
+
+  await userEvent.type(screen.getByLabelText("Start date"), "2020-01-01");
+  expect(applyButton).toBeDisabled();
+
+  await userEvent.type(screen.getByLabelText("End date"), "2020-01-31");
+  expect(applyButton).toBeEnabled();
+});
+
+test("AC-14: start-after-end is blocked client-side with an inline error and no network call", async () => {
+  setupFetchMock(() => jsonResponse(200, page(unfilteredItems)));
+  render(<TransactionContainer id={1} />);
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+
+  await userEvent.type(screen.getByLabelText("Start date"), "2020-02-01");
+  await userEvent.type(screen.getByLabelText("End date"), "2020-01-01");
+  await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent(
+    "Start date cannot be after end date"
+  );
+  expect(transactionCalls()).toHaveLength(1);
+});
+
+test("AC-14: a future date is blocked client-side with an inline error and no network call", async () => {
+  setupFetchMock(() => jsonResponse(200, page(unfilteredItems)));
+  render(<TransactionContainer id={1} />);
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+
+  const futureYear = new Date().getFullYear() + 1;
+  await userEvent.type(screen.getByLabelText("Start date"), "2020-01-01");
+  await userEvent.type(screen.getByLabelText("End date"), `${futureYear}-01-01`);
+  await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+  expect(screen.getByRole("alert")).toHaveTextContent("Date cannot be in the future");
+  expect(transactionCalls()).toHaveLength(1);
+});
+
+test("AC-15: a successful Apply refetches with startDate/endDate, resets to page 1, and reflects filtered pagination", async () => {
+  setupFetchMock((url) => {
+    if (url.includes("startDate=")) {
+      return jsonResponse(200, page([unfilteredItems[0]], { totalPages: 3 }));
+    }
+    return jsonResponse(200, page(unfilteredItems, { totalPages: 1 }));
+  });
+  render(<TransactionContainer id={1} />);
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+
+  await userEvent.type(screen.getByLabelText("Start date"), "2020-01-01");
+  await userEvent.type(screen.getByLabelText("End date"), "2020-01-31");
+  await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+  await waitFor(() => expect(transactionCalls()).toHaveLength(2));
+  const url = lastTransactionCallUrl();
+  expect(url.searchParams.get("startDate")).toBe("2020-01-01");
+  expect(url.searchParams.get("endDate")).toBe("2020-01-31");
+  expect(url.searchParams.get("page")).toBe("0");
+
+  // Filtered result set reports 3 pages - pagination controls reflect that.
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: "3" })).toBeInTheDocument()
+  );
+});
+
+test("AC-16: Clear resets both inputs, clears the applied filter, and refetches the full unfiltered list at page 1", async () => {
+  setupFetchMock((url) => {
+    if (url.includes("startDate=")) {
+      return jsonResponse(200, page([], { totalPages: 0 }));
+    }
+    return jsonResponse(200, page(unfilteredItems, { totalPages: 1 }));
+  });
+  render(<TransactionContainer id={1} />);
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+
+  await userEvent.type(screen.getByLabelText("Start date"), "2020-01-01");
+  await userEvent.type(screen.getByLabelText("End date"), "2020-01-31");
+  await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+  await waitFor(() => expect(transactionCalls()).toHaveLength(2));
+
+  await userEvent.click(screen.getByRole("button", { name: "Clear" }));
+
+  expect(screen.getByLabelText("Start date")).toHaveValue("");
+  expect(screen.getByLabelText("End date")).toHaveValue("");
+  await waitFor(() => expect(transactionCalls()).toHaveLength(3));
+  const url = lastTransactionCallUrl();
+  expect(url.searchParams.get("startDate")).toBeNull();
+  expect(url.searchParams.get("endDate")).toBeNull();
+  expect(url.searchParams.get("page")).toBe("0");
+});
+
+test("AC-17: shows a minimal loading indicator while a filtered fetch is in flight", async () => {
+  let resolveFilteredFetch;
+  setupFetchMock((url) => {
+    if (url.includes("startDate=")) {
+      return new Promise((resolve) => {
+        resolveFilteredFetch = () => resolve(jsonResponse(200, page(unfilteredItems)));
+      });
+    }
+    return jsonResponse(200, page(unfilteredItems));
+  });
+  render(<TransactionContainer id={1} />);
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+
+  await userEvent.type(screen.getByLabelText("Start date"), "2020-01-01");
+  await userEvent.type(screen.getByLabelText("End date"), "2020-01-31");
+  await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+  expect(await screen.findByRole("status")).toHaveTextContent(
+    "Loading filtered transactions"
+  );
+
+  resolveFilteredFetch();
+  await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument());
+});
+
+test("AC-18: a valid range with zero results shows a distinct message, not the loading or pre-filter empty state", async () => {
+  setupFetchMock((url) => {
+    if (url.includes("startDate=")) {
+      return jsonResponse(200, page([], { totalPages: 0 }));
+    }
+    return jsonResponse(200, page(unfilteredItems));
+  });
+  render(<TransactionContainer id={1} />);
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+
+  await userEvent.type(screen.getByLabelText("Start date"), "2020-01-01");
+  await userEvent.type(screen.getByLabelText("End date"), "2020-01-31");
+  await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+  await waitFor(() =>
+    expect(screen.getByText("No transactions in this date range")).toBeInTheDocument()
+  );
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
+});
+
+test("AC-20: paginating while a filter is applied keeps the filter active on subsequent requests", async () => {
+  setupFetchMock((url) => {
+    if (url.includes("startDate=")) {
+      return jsonResponse(200, page(unfilteredItems, { totalPages: 3 }));
+    }
+    return jsonResponse(200, page(unfilteredItems, { totalPages: 1 }));
+  });
+  render(<TransactionContainer id={1} />);
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+
+  await userEvent.type(screen.getByLabelText("Start date"), "2020-01-01");
+  await userEvent.type(screen.getByLabelText("End date"), "2020-01-31");
+  await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+  await waitFor(() => expect(transactionCalls()).toHaveLength(2));
+  // Wait for the filtered response to actually land in state (3 pages)
+  // before interacting further, rather than racing the still-pending fetch.
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: "3" })).toBeInTheDocument()
+  );
+
+  await userEvent.click(screen.getByRole("button", { name: "2" }));
+
+  await waitFor(() => expect(transactionCalls()).toHaveLength(3));
+  const url = lastTransactionCallUrl();
+  expect(url.searchParams.get("page")).toBe("1");
+  expect(url.searchParams.get("startDate")).toBe("2020-01-01");
+  expect(url.searchParams.get("endDate")).toBe("2020-01-31");
+});

--- a/fm-ui/src/components/TransactionContainer.test.jsx
+++ b/fm-ui/src/components/TransactionContainer.test.jsx
@@ -226,6 +226,34 @@ test("AC-18: a valid range with zero results shows a distinct message, not the l
   expect(screen.queryByRole("status")).not.toBeInTheDocument();
 });
 
+test("bug fix: a server-side rejection of a filtered request (plain-text 400 body) surfaces an error instead of showing stale pre-filter items as the filtered result", async () => {
+  setupFetchMock((url) => {
+    if (url.includes("startDate=")) {
+      // AccountController/AccountService return a plain-text body on
+      // rejection, not JSON - this reproduces that, e.g. from clock skew
+      // making a client-valid request fail server-side validation.
+      return jsonResponse(400, "Date cannot be in the future");
+    }
+    return jsonResponse(200, page(unfilteredItems));
+  });
+  render(<TransactionContainer id={1} />);
+  await waitFor(() => expect(transactionCalls()).toHaveLength(1));
+  expect(await screen.findByText("Tesco")).toBeInTheDocument();
+
+  await userEvent.type(screen.getByLabelText("Start date"), "2020-01-01");
+  await userEvent.type(screen.getByLabelText("End date"), "2020-01-31");
+  await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+  await waitFor(() => expect(transactionCalls()).toHaveLength(2));
+  expect(await screen.findByRole("alert")).toHaveTextContent(
+    "Date cannot be in the future"
+  );
+  // The pre-filter row must not remain on screen looking like a valid
+  // filtered result, and the loading indicator must have cleared.
+  expect(screen.queryByText("Tesco")).not.toBeInTheDocument();
+  expect(screen.queryByRole("status")).not.toBeInTheDocument();
+});
+
 test("AC-20: paginating while a filter is applied keeps the filter active on subsequent requests", async () => {
   setupFetchMock((url) => {
     if (url.includes("startDate=")) {


### PR DESCRIPTION
## Summary

Adds an opt-in date-range filter to the account page's transaction table, addressing the ticket's core complaint that the transaction list is "too much" to navigate.

- **Backend** (`196889a`): `GET /accounts/account/{id}/transactions` gains optional `startDate`/`endDate` query params (ISO `yyyy-MM-dd`), applied as an inclusive range. Validation lives in `AccountService` (both-required, no inverted range, no dates beyond today — today itself is a valid end date) and returns 400 with a plain-text message on violation, matching `TransactionController`'s existing error-response pattern. The unfiltered path (neither param supplied) is untouched and still calls the original query byte-for-byte.
- **Frontend** (`8c8ccfe`, `f96d1af`, `3d31d79`): native `<input type="date">` fields + Apply/Clear controls added to `TransactionContainer`, scoped to the transaction table only (the account page's monthly chart is unaffected).

## Key decisions & reasoning

- **Show-all-by-default, opt-in filter, explicit Apply** (per Amigos): input state (what's typed) is tracked separately from applied state (what was last actually fetched), so picking a date never triggers a network call — only clicking Apply does. This was a deliberate UX choice to avoid noisy re-fetching while a user is still choosing a range.
- **Invalid range is rejected, not silently corrected** (per Amigos): a start date after the end date, or either date beyond today, shows an inline error and blocks the request — mirrored on both the frontend (fast-fail, no network call) and backend (source of truth, enforced independently of the UI).
- **Date filter duplicated onto the repository's countQuery**: `TransactionRepository`'s row-fetch and count queries are separate hand-written native queries — Spring Data doesn't derive one from the other. Missing this on the countQuery would have silently reported the wrong (unfiltered) `totalPages`/`totalElements` once a filter actually narrowed the result set. This was flagged as a risk going in and is covered by a dedicated multi-page H2 repository test.
- **Surfacing filtered-fetch errors** (bug found and fixed in `f96d1af`): the initial implementation didn't check `response.ok` before calling `response.json()`. Since `AccountController` returns a plain-text body on rejection (not JSON), a 400 would throw, get swallowed by the generic catch, and leave stale pre-filter data on screen looking like a valid filtered result. Fixed to read the response as text and surface the server's actual message on failure, clearing items instead of showing stale ones.
- **Side-fix**: `TransactionContainer` was sending a `limit` query param for page size, but the backend has always read `size` — pagination was silently defaulting to 10 regardless of the configured page size. Fixed while touching this line.

## Intent check

Verified this actually solves the ticket's stated problem (list "too much," need "ease of navigation") rather than just satisfying the acceptance criteria literally: the filter sits directly above the transaction table (visible as soon as a user views transactions), lets a user jump straight to a relevant date range instead of paging through the full history, and the show-all-by-default/explicit-Apply behavior keeps the existing view intact for anyone who doesn't need to filter.

## What was tested, and how

- Backend: `AccountControllerTest`, `AccountServiceTest`, and a dedicated `TransactionDateRangePaginationRepositoryTest` (H2, multi-page, asserts the countQuery reflects the filtered subset, not the account total) — 20 tests, spot-re-run independently as part of sign-off, all passing.
- Frontend: 13 tests in `TransactionContainer.test.jsx` covering initial unfiltered load, input-vs-applied state separation, Apply gating, client-side validation (including the `endDate == today` boundary), successful filtered fetch + pagination reset, Clear, loading indicator, empty-filtered-result state, filter persistence across pagination, the server-error-surfacing bug fix, and the `size`-not-`limit` pagination fix — spot-re-run independently, all passing.
- QA independently ran both full suites (backend 105 tests, frontend full suite), mapped all 20 acceptance criteria to assertion-level tests, found and closed one gap (the `endDate == today` boundary was untested on the frontend), and confirmed no regressions (one pre-existing, unrelated `App.test.js` failure exists on `main` too, unaffected by this change).

## Deferred / flagged (non-blocking)

1. Malformed/unparseable date query params (garbage text, not a business-rule violation) would hit Spring's default JSON error response rather than this feature's plain-text error contract. Currently unreachable from the shipped UI since native `<input type="date">` can't produce garbage — only relevant to a hypothetical future API consumer (e.g. Postman, another client).
2. As a side effect of the new error handling, a previously-uncaught invalid page/size param (e.g. negative page) now returns 400 instead of an uncaught 500 — a strict improvement, unrequested but not a regression.
3. No filter-state persistence across refresh/navigation — by design, per the Amigos decisions.
4. The date filter does not affect the account page's monthly chart — by design, per the Amigos decisions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>